### PR TITLE
Add repeated races, timeouts, and failure diagnostics

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
-        java: [21]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/README.md
+++ b/README.md
@@ -69,6 +69,88 @@ and makes sure that all of them return `true`. If at least
 one of them returns `false`, the test fails. If at least one of the
 threads throws an exception, the test also fails.
 
+The existing constructors remain unchanged, but you may now make the
+test stronger without changing the original style:
+
+```java
+import java.util.concurrent.TimeUnit;
+
+new Together<>(
+  8,
+  thread -> service.process(thread)
+).repeated(100)
+  .withTimeout(1, TimeUnit.SECONDS)
+  .failFast()
+  .asList();
+```
+
+Use `repeated(...)` when you want to run the same race many times,
+`withTimeout(...)` when you don't want a stuck thread to freeze the test,
+and `failFast()` when you want the remaining threads to be interrupted as
+soon as one execution fails.
+
+When a thread fails, the library now throws `TogetherFailure`, which is still
+an `IllegalArgumentException` for backward compatibility, but it also tells
+you which round failed, which thread failed, whether timeout was exceeded,
+and how long the execution lasted.
+
+Here are a few focused examples.
+
+Repeat the same race many times:
+
+```java
+MatcherAssert.assertThat(
+  new Together<>(
+    4,
+    thread -> cache.get("hello")
+  ).repeated(250),
+  Matchers.everyItem(Matchers.equalTo("world"))
+);
+```
+
+Stop a deadlocked or stuck test after a timeout:
+
+```java
+Assertions.assertThrows(
+  TogetherFailure.class,
+  () -> new Together<>(
+    2,
+    thread -> {
+      Thread.sleep(10_000L);
+      return thread;
+    }
+  ).withTimeout(50L, TimeUnit.MILLISECONDS).asList()
+);
+```
+
+Fail immediately when the first thread breaks:
+
+```java
+Assertions.assertThrows(
+  TogetherFailure.class,
+  () -> new Together<>(
+    8,
+    thread -> service.process(thread)
+  ).failFast().asList()
+);
+```
+
+Inspect the richer failure details:
+
+```java
+final TogetherFailure failure = Assertions.assertThrows(
+  TogetherFailure.class,
+  () -> new Together<>(
+    1,
+    thread -> {
+      throw new IllegalStateException("boom");
+    }
+  ).repeated(10).asList()
+);
+MatcherAssert.assertThat(failure.happenedInRound(0), Matchers.is(true));
+MatcherAssert.assertThat(failure.happenedInThread(0), Matchers.is(true));
+```
+
 `Together` guarantees that all threads start exactly simultaneously,
 thus simulating [race condition] as much as it's possible. This is exactly
 what you need for your tests: making sure your object under test

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.26.0</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,9 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+  </properties>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <properties>
-    <maven.compiler.release>21</maven.compiler.release>
-  </properties>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.26.0</version>
+            <version>0.27.0</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/src/main/java/com/yegor256/Together.java
+++ b/src/main/java/com/yegor256/Together.java
@@ -4,91 +4,30 @@
  */
 package com.yegor256;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
+import com.yegor256.together.race.Race;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Runs lambda function in multiple threads.
  *
- * <p>Use it like this, in your JUnit5 test (with Hamcrest):</p>
- *
- * <code><pre> import org.hamcrest.MatcherAssert;
- * import org.hamcrest.Matchers;
- * import org.junit.jupiter.api.Test;
- * import org.junit.jupiter.api.io.TempDir;
- * import com.yegor256.Together;
- *
- * class FooTest {
- *   &#64;Test
- *   void worksAsExpected() {
- *     MatcherAssert.assertThat(
- *       "processes all lambdas successfully",
- *       new Together&lt;&gt;(
- *         () -&gt; {
- *           // do the job
- *           return true;
- *         }
- *       ),
- *       Matchers.not(Matchers.hasItem(Matchers.is(false)))
- *     );
- *   }
- * }</pre></code>
- *
- * <p>Here, the {@link Together} class will run the "job" in multiple threads
- * and will make sure that all of them return {@code true}. If at least
- * one of them returns {@code false}, the test will fail. If at least one of the
- * threads will throw an exception, the test will also fail.</p>
- *
- * <p>{@link Together} guarantees that all threads will start exactly
- * simultaneously,
- * thus simulating race condition as much as it's possible. This is exactly
- * what you need for your tests: making sure your object under test
- * experiences troubles that are very similar to what it might experience
- * in real life.</p>
- *
  * @param <T> The type of result
- * @see <a href="https://www.yegor256.com/2018/03/27/how-to-test-thread-safety.html">How I Test My Java Classes for Thread-Safety</a>
- * @see <a href="https://junit.org/junit5/">JUnit5</a>
- * @see <a href="http://hamcrest.org">Hamcrest</a>
- * @see <a href="https://en.wikipedia.org/wiki/Race_condition">Race condition</a>
- * @see <a href="https://github.com/yegor256/together">GitHub repository</a>
  * @since 0.0.1
  */
 public final class Together<T> implements Iterable<T> {
 
     /**
-     * Total number of threads to use.
+     * Race to execute.
      */
-    private final int threads;
-
-    /**
-     * The action to perform.
-     */
-    private final Together.Action<T> action;
+    private final Race<T> race;
 
     /**
      * Ctor.
-     *
-     * <p>The number of threads here will be the maximum of current
-     * available CPUs on the host machine and the number three. Thus, at
-     * least three threads will be executed.</p>
-     *
      * @param act The action
      */
     public Together(final Together.Action<T> act) {
-        this(Math.max(Runtime.getRuntime().availableProcessors(), 3), act);
+        this(new Race<>(act));
     }
 
     /**
@@ -97,57 +36,50 @@ public final class Together<T> implements Iterable<T> {
      * @param act The action
      */
     public Together(final int total, final Together.Action<T> act) {
-        this.threads = total;
-        this.action = act;
+        this(new Race<>(total, act));
+    }
+
+    /**
+     * Private ctor.
+     * @param origin Race to execute
+     */
+    private Together(final Race<T> origin) {
+        this.race = origin;
+    }
+
+    /**
+     * Repeat each race condition many times.
+     * @param total Number of rounds
+     * @return New instance
+     * @since 1.0
+     */
+    public Together<T> repeated(final int total) {
+        return new com.yegor256.Together<>(this.race.repeated(total));
+    }
+
+    /**
+     * Limit the execution time of every round.
+     * @param limit Timeout limit
+     * @param unit Timeout unit
+     * @return New instance
+     * @since 1.0
+     */
+    public Together<T> withTimeout(final long limit, final TimeUnit unit) {
+        return new com.yegor256.Together<>(this.race.withTimeout(limit, unit));
+    }
+
+    /**
+     * Stop waiting as soon as one thread fails.
+     * @return New instance
+     * @since 1.0
+     */
+    public Together<T> failFast() {
+        return new com.yegor256.Together<>(this.race.failFast());
     }
 
     @Override
-    @SuppressWarnings("PMD.DoNotThrowExceptionInFinally")
     public Iterator<T> iterator() {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final ExecutorService service =
-            Executors.newFixedThreadPool(this.threads);
-        try {
-            final Map<Integer, Future<T>> futures =
-                new HashMap<>();
-            for (final int pos : new Shuffled(this.threads)) {
-                futures.put(
-                    pos,
-                    service.submit(
-                        () -> {
-                            latch.await();
-                            return this.action.apply(pos);
-                        }
-                    )
-                );
-            }
-            latch.countDown();
-            final Collection<T> rets = new LinkedList<>();
-            for (int index = 0; index < this.threads; ++index) {
-                try {
-                    rets.add(futures.get(index).get());
-                } catch (final InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                    throw new IllegalArgumentException(ex);
-                } catch (final ExecutionException ex) {
-                    throw new IllegalArgumentException(ex);
-                }
-            }
-            return new Together.Iter<>(rets, rets.iterator());
-        } finally {
-            service.shutdown();
-            try {
-                if (!service.awaitTermination(1L, TimeUnit.MINUTES)) {
-                    service.shutdownNow();
-                    if (!service.awaitTermination(1L, TimeUnit.MINUTES)) {
-                        throw new IllegalStateException("Can't shutdown");
-                    }
-                }
-            } catch (final InterruptedException ex) {
-                Thread.currentThread().interrupt();
-                throw new IllegalArgumentException(ex);
-            }
-        }
+        return this.race.iterator();
     }
 
     /**
@@ -156,11 +88,7 @@ public final class Together<T> implements Iterable<T> {
      * @since 0.0.3
      */
     public List<T> asList() {
-        final List<T> list = new LinkedList<>();
-        for (final T item : this) {
-            list.add(item);
-        }
-        return list;
+        return this.race.asList();
     }
 
     /**
@@ -178,80 +106,5 @@ public final class Together<T> implements Iterable<T> {
          * @throws Exception If fails
          */
         T apply(int thread) throws Exception;
-    }
-
-    /**
-     * The iterator.
-     *
-     * @param <T> The type of result
-     * @since 0.0.2
-     */
-    private static final class Iter<T> implements Iterator<T> {
-        /**
-         * The list of items.
-         */
-        private final Collection<T> items;
-
-        /**
-         * The iterator.
-         */
-        private final Iterator<T> iterator;
-
-        /**
-         * Ctor.
-         * @param list The list
-         * @param iter The iterator
-         */
-        Iter(final Collection<T> list, final Iterator<T> iter) {
-            this.items = list;
-            this.iterator = iter;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return this.iterator.hasNext();
-        }
-
-        @Override
-        public T next() {
-            return this.iterator.next();
-        }
-
-        @Override
-        public String toString() {
-            final StringBuilder text = new StringBuilder(16).append('[');
-            for (final T item : this.items) {
-                if (text.length() > 1) {
-                    text.append(", ");
-                }
-                text.append(item);
-            }
-            return text.append(']').toString();
-        }
-    }
-
-    /**
-     * Shuffled sequence of integers.
-     * @since 0.1.1
-     */
-    private static final class Shuffled implements Iterable<Integer> {
-        /**
-         * The size of items.
-         */
-        private final int size;
-
-        Shuffled(final int size) {
-            this.size = size;
-        }
-
-        @Override
-        public Iterator<Integer> iterator() {
-            final List<Integer> items = new ArrayList<>(this.size);
-            for (int idx = 0; idx < this.size; ++idx) {
-                items.add(idx);
-            }
-            Collections.shuffle(items);
-            return items.iterator();
-        }
     }
 }

--- a/src/main/java/com/yegor256/Together.java
+++ b/src/main/java/com/yegor256/Together.java
@@ -11,7 +11,49 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Runs lambda function in multiple threads.
+ *
+ * <p>Use it like this, in your JUnit5 test (with Hamcrest):</p>
+ *
+ * <code><pre> import org.hamcrest.MatcherAssert;
+ * import org.hamcrest.Matchers;
+ * import org.junit.jupiter.api.Test;
+ * import org.junit.jupiter.api.io.TempDir;
+ * import com.yegor256.Together;
+ *
+ * class FooTest {
+ *   &#64;Test
+ *   void worksAsExpected() {
+ *     MatcherAssert.assertThat(
+ *       "processes all lambdas successfully",
+ *       new Together&lt;&gt;(
+ *         () -&gt; {
+ *           // do the job
+ *           return true;
+ *         }
+ *       ),
+ *       Matchers.not(Matchers.hasItem(Matchers.is(false)))
+ *     );
+ *   }
+ * }</pre></code>
+ *
+ * <p>Here, the {@link Together} class will run the "job" in multiple threads
+ * and will make sure that all of them return {@code true}. If at least
+ * one of them returns {@code false}, the test will fail. If at least one of the
+ * threads will throw an exception, the test will also fail.</p>
+ *
+ * <p>{@link Together} guarantees that all threads will start exactly
+ * simultaneously,
+ * thus simulating race condition as much as it's possible. This is exactly
+ * what you need for your tests: making sure your object under test
+ * experiences troubles that are very similar to what it might experience
+ * in real life.</p>
+ *
  * @param <T> The type of result
+ * @see <a href="https://www.yegor256.com/2018/03/27/how-to-test-thread-safety.html">How I Test My Java Classes for Thread-Safety</a>
+ * @see <a href="https://junit.org/junit5/">JUnit5</a>
+ * @see <a href="http://hamcrest.org">Hamcrest</a>
+ * @see <a href="https://en.wikipedia.org/wiki/Race_condition">Race condition</a>
+ * @see <a href="https://github.com/yegor256/together">GitHub repository</a>
  * @since 0.0.1
  */
 public final class Together<T> implements Iterable<T> {

--- a/src/main/java/com/yegor256/Together.java
+++ b/src/main/java/com/yegor256/Together.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Runs lambda function in multiple threads.
- *
  * @param <T> The type of result
  * @since 0.0.1
  */
@@ -93,12 +92,12 @@ public final class Together<T> implements Iterable<T> {
 
     /**
      * Action to perform.
-     *
      * @param <T> The type of result
      * @since 0.0.1
      */
     @FunctionalInterface
     public interface Action<T> {
+
         /**
          * Apply it.
          * @param thread The thread number

--- a/src/main/java/com/yegor256/TogetherFailure.java
+++ b/src/main/java/com/yegor256/TogetherFailure.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Failure of one concurrent execution.
- *
  * @since 1.0
  */
 @SuppressWarnings("serial")

--- a/src/main/java/com/yegor256/TogetherFailure.java
+++ b/src/main/java/com/yegor256/TogetherFailure.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256;
+
+import com.yegor256.together.failure.FailureContext;
+import com.yegor256.together.failure.FailureDescription;
+import com.yegor256.together.failure.FailureKind;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Failure of one concurrent execution.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("serial")
+public final class TogetherFailure extends IllegalArgumentException {
+
+    /**
+     * Failure description.
+     */
+    private final FailureDescription description;
+
+    /**
+     * Ctor.
+     * @param details Failure context
+     * @param failure Failure kind
+     * @param cause Root cause
+     */
+    // @checkstyle ConstructorsCodeFreeCheck (1 line)
+    public TogetherFailure(final FailureContext details,
+        final FailureKind failure, final Throwable cause) {
+        super("", cause);
+        this.description = new com.yegor256.together.failure.FailureDescription(
+            details, failure
+        );
+    }
+
+    /**
+     * Whether timeout caused this failure.
+     * @return TRUE if timeout happened
+     */
+    public boolean causedByTimeout() {
+        return this.description.causedByTimeout();
+    }
+
+    /**
+     * Whether it happened in this round.
+     * @param number Round number
+     * @return TRUE if yes
+     */
+    public boolean happenedInRound(final int number) {
+        return this.description.happenedInRound(number);
+    }
+
+    /**
+     * Whether it happened in this thread.
+     * @param number Thread number
+     * @return TRUE if yes
+     */
+    public boolean happenedInThread(final int number) {
+        return this.description.happenedInThread(number);
+    }
+
+    /**
+     * Whether it lasted at least this long.
+     * @param duration Duration
+     * @param unit Time unit
+     * @return TRUE if yes
+     */
+    public boolean lastedAtLeast(final long duration, final TimeUnit unit) {
+        return this.description.lastedAtLeast(duration, unit);
+    }
+
+    @Override
+    public String getMessage() {
+        return this.description.messageText();
+    }
+}

--- a/src/main/java/com/yegor256/package-info.java
+++ b/src/main/java/com/yegor256/package-info.java
@@ -4,7 +4,7 @@
  */
 
 /**
- * There is only one class {@link com.yegor256.Together} that helps
+ * The main entry point is {@link com.yegor256.Together}, which helps
  * you run a single lambda in multiple threads.
  *
  * @since 0.0.1

--- a/src/main/java/com/yegor256/package-info.java
+++ b/src/main/java/com/yegor256/package-info.java
@@ -6,7 +6,6 @@
 /**
  * The main entry point is {@link com.yegor256.Together}, which helps
  * you run a single lambda in multiple threads.
- *
  * @since 0.0.1
  * @see <a href="https://github.com/yegor256/together">GitHub repository</a>
  * @see <a href="https://www.yegor256.com/2018/03/27/how-to-test-thread-safety.html">How I Test My Java Classes for Thread-Safety</a>

--- a/src/main/java/com/yegor256/together/execution/Completed.java
+++ b/src/main/java/com/yegor256/together/execution/Completed.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 /**
  * Completed executions.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/execution/Completed.java
+++ b/src/main/java/com/yegor256/together/execution/Completed.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import com.yegor256.together.race.Threads;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Completed executions.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Completed<T> {
+
+    /**
+     * Thread layout.
+     */
+    private final Threads threads;
+
+    /**
+     * Completed executions.
+     */
+    private final Map<Integer, Execution<T>> done;
+
+    /**
+     * Ctor.
+     * @param all Threads
+     */
+    public Completed(final Threads all) {
+        this(all, new HashMap<>());
+    }
+
+    /**
+     * Private ctor.
+     * @param all Threads
+     * @param map Completed executions
+     */
+    private Completed(final Threads all, final Map<Integer, Execution<T>> map) {
+        this.threads = all;
+        this.done = map;
+    }
+
+    /**
+     * Add one execution.
+     * @param execution Next execution
+     * @return This collector
+     */
+    public Completed<T> with(final Execution<T> execution) {
+        execution.placeInto(this.done);
+        return this;
+    }
+
+    /**
+     * Whether more executions are expected.
+     * @return TRUE if yes
+     */
+    public boolean isIncomplete() {
+        return this.threads.misses(new HashMap<Integer, Execution<?>>(this.done));
+    }
+
+    /**
+     * Missing thread number.
+     * @return Thread number
+     */
+    public int missingThread() {
+        return this.threads.firstAbsentFrom(new HashMap<Integer, Execution<?>>(this.done));
+    }
+
+    /**
+     * Stop if any failure already happened.
+     * @param round Round number
+     * @param started Started execution
+     */
+    public void stopFastIn(final int round, final Started<T> started) {
+        for (final Execution<T> execution : this.done.values()) {
+            execution.stopFastIn(round, started);
+        }
+    }
+
+    /**
+     * Final results.
+     * @param round Round number
+     * @return Results
+     */
+    public List<T> resultsIn(final int round) {
+        final List<T> results = new LinkedList<>();
+        this.threads.appendTo(this.done, round, results);
+        return results;
+    }
+}

--- a/src/main/java/com/yegor256/together/execution/Execution.java
+++ b/src/main/java/com/yegor256/together/execution/Execution.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 /**
  * One execution result.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/execution/Execution.java
+++ b/src/main/java/com/yegor256/together/execution/Execution.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import com.yegor256.TogetherFailure;
+import com.yegor256.together.failure.FailureContext;
+import com.yegor256.together.failure.FailureKind;
+import com.yegor256.together.failure.RaisedFailure;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One execution result.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Execution<T> {
+
+    /**
+     * Thread number.
+     */
+    private final int thread;
+
+    /**
+     * Result.
+     */
+    private final T result;
+
+    /**
+     * Failure.
+     */
+    private final Exception failure;
+
+    /**
+     * Elapsed time.
+     */
+    private final long elapsed;
+
+    /**
+     * Ctor for success.
+     * @param number Thread number
+     * @param value Result
+     * @param msec Elapsed
+     */
+    public Execution(final int number, final T value, final long msec) {
+        // @checkstyle ParameterNumberCheck (1 line)
+        this(number, value, null, msec);
+    }
+
+    /**
+     * Ctor for failure.
+     * @param number Thread number
+     * @param problem Failure
+     * @param msec Elapsed
+     */
+    public Execution(final int number, final Exception problem, final long msec) {
+        // @checkstyle ParameterNumberCheck (1 line)
+        this(number, null, problem, msec);
+    }
+
+    /**
+     * Private ctor.
+     * @param number Thread number
+     * @param value Result
+     * @param problem Failure
+     * @param msec Elapsed
+     */
+    // @checkstyle ParameterNumberCheck (3 lines)
+    private Execution(final int number, final T value, final Exception problem,
+        final long msec) {
+        this.thread = number;
+        this.result = value;
+        this.failure = problem;
+        this.elapsed = msec;
+    }
+
+    /**
+     * Put into the map.
+     * @param all Mutable map
+     */
+    public void placeInto(final Map<Integer, Execution<T>> all) {
+        all.put(this.thread, this);
+    }
+
+    /**
+     * Stop fast if this execution failed.
+     * @param round Round number
+     * @param started Started execution
+     */
+    public void stopFastIn(final int round, final Started<T> started) {
+        if (this.failure != null) {
+            started.stop();
+            throw this.failureIn(round);
+        }
+    }
+
+    /**
+     * Complete the round.
+     * @param round Round number
+     * @param results Mutable results
+     */
+    public void complete(final int round, final List<T> results) {
+        if (this.failure != null) {
+            throw this.failureIn(round);
+        }
+        results.add(this.result);
+    }
+
+    /**
+     * Convert to public failure.
+     * @param round Round number
+     * @return Failure
+     */
+    public TogetherFailure failureIn(final int round) {
+        return new RaisedFailure(
+            new FailureContext(round, this.thread, this.elapsed),
+            new FailureKind(false, this.failure.getMessage())
+        ).asPublic(this.failure);
+    }
+}

--- a/src/main/java/com/yegor256/together/execution/Job.java
+++ b/src/main/java/com/yegor256/together/execution/Job.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * One concurrent job.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/execution/Job.java
+++ b/src/main/java/com/yegor256/together/execution/Job.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import com.yegor256.Together;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * One concurrent job.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Job<T> implements Callable<Execution<T>> {
+
+    /**
+     * Start latch.
+     */
+    private final CountDownLatch latch;
+
+    /**
+     * Thread number.
+     */
+    private final int thread;
+
+    /**
+     * Action.
+     */
+    private final Together.Action<T> action;
+
+    /**
+     * Ctor.
+     * @param shared Shared latch
+     * @param number Thread number
+     * @param job Action
+     */
+    public Job(final CountDownLatch shared, final int number,
+        final Together.Action<T> job) {
+        this.latch = shared;
+        this.thread = number;
+        this.action = job;
+    }
+
+    @Override
+    public Execution<T> call() throws Exception {
+        this.latch.await();
+        return new Execution<>(
+            this.thread,
+            this.action.apply(this.thread),
+            Job.elapsed(System.nanoTime())
+        );
+    }
+
+    /**
+     * Elapsed time in milliseconds.
+     * @param start Start time
+     * @return Milliseconds
+     */
+    private static long elapsed(final long start) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+    }
+}

--- a/src/main/java/com/yegor256/together/execution/Started.java
+++ b/src/main/java/com/yegor256/together/execution/Started.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Started round execution.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/execution/Started.java
+++ b/src/main/java/com/yegor256/together/execution/Started.java
@@ -1,0 +1,229 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import com.yegor256.TogetherFailure;
+import com.yegor256.together.failure.FailureContext;
+import com.yegor256.together.failure.FailureKind;
+import com.yegor256.together.failure.RaisedFailure;
+import com.yegor256.together.policy.Deadline;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Started round execution.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Started<T> {
+
+    /**
+     * Shared latch.
+     */
+    private final CountDownLatch latch;
+
+    /**
+     * Completion service.
+     */
+    private final CompletionService<Execution<T>> completion;
+
+    /**
+     * All futures.
+     */
+    private final Map<Integer, Future<Execution<T>>> futures;
+
+    /**
+     * Start time.
+     */
+    private long begun;
+
+    /**
+     * Ctor.
+     * @param shared Shared latch
+     * @param service Completion service
+     * @param all Futures
+     */
+    public Started(final CountDownLatch shared,
+        final CompletionService<Execution<T>> service,
+        final Map<Integer, Future<Execution<T>>> all) {
+        this.latch = shared;
+        this.completion = service;
+        this.futures = new HashMap<>(all);
+    }
+
+    /**
+     * Start all jobs.
+     */
+    public void start() {
+        this.begun = System.nanoTime();
+        this.latch.countDown();
+    }
+
+    /**
+     * Wait forever for next execution.
+     * @param round Round number
+     * @return Execution
+     */
+    public Execution<T> next(final int round) {
+        final Future<Execution<T>> future;
+        try {
+            future = this.completion.take();
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            this.stop();
+            throw Started.failure(
+                new FailureContext(round, -1, this.elapsed()), false, ex
+            );
+        }
+        return this.execution(round, future);
+    }
+
+    /**
+     * Wait with timeout.
+     * @param round Round number
+     * @param deadline Timeout deadline
+     * @param pending Missing thread
+     * @return Execution
+     */
+    public Execution<T> next(final int round, final Deadline deadline,
+        final int pending) {
+        final Future<Execution<T>> future = this.next(deadline, round);
+        if (future == null) {
+            this.stop();
+            throw Started.failure(
+                new FailureContext(round, pending, this.elapsed()),
+                true,
+                new TimeoutException("Timeout was exceeded")
+            );
+        }
+        return this.execution(round, future);
+    }
+
+    /**
+     * Stop all jobs.
+     */
+    public void stop() {
+        for (final Future<Execution<T>> future : this.futures.values()) {
+            future.cancel(true);
+        }
+    }
+
+    /**
+     * Elapsed time in milliseconds.
+     * @return Milliseconds
+     */
+    public long elapsed() {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - this.begun);
+    }
+
+    /**
+     * Wait with timeout.
+     * @param deadline Timeout deadline
+     * @param round Round number
+     * @return Future or NULL
+     */
+    private Future<Execution<T>> next(final Deadline deadline, final int round) {
+        final Future<Execution<T>> future;
+        try {
+            future = this.completion.poll(
+                deadline.from(this.begun),
+                deadline.timeUnit()
+            );
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            this.stop();
+            throw Started.failure(
+                new FailureContext(round, -1, this.elapsed()), false, ex
+            );
+        }
+        return future;
+    }
+
+    /**
+     * Read execution from future.
+     * @param round Round number
+     * @param future Future
+     * @return Execution
+     */
+    private Execution<T> execution(final int round,
+        final Future<Execution<T>> future) {
+        try {
+            return future.get();
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            this.stop();
+            throw Started.failure(
+                new FailureContext(round, this.threadOf(future), this.elapsed()),
+                false,
+                ex
+            );
+        } catch (final ExecutionException ex) {
+            this.stop();
+            throw Started.failure(
+                new FailureContext(round, this.threadOf(future), this.elapsed()),
+                false,
+                Started.reasonOf(ex)
+            );
+        } catch (final CancellationException ex) {
+            this.stop();
+            throw Started.failure(
+                new FailureContext(round, this.threadOf(future), this.elapsed()),
+                false,
+                ex
+            );
+        }
+    }
+
+    /**
+     * Thread number of the future.
+     * @param future Future to find
+     * @return Thread number
+     */
+    private int threadOf(final Future<Execution<T>> future) {
+        int thread = -1;
+        for (final Map.Entry<Integer, Future<Execution<T>>> entry
+            : this.futures.entrySet()) {
+            if (entry.getValue().equals(future)) {
+                thread = entry.getKey();
+                break;
+            }
+        }
+        return thread;
+    }
+
+    /**
+     * Root cause of execution failure.
+     * @param exception Failure
+     * @return Cause
+     */
+    private static Throwable reasonOf(final ExecutionException exception) {
+        Throwable reason = exception;
+        if (exception.getCause() != null) {
+            reason = exception.getCause();
+        }
+        return reason;
+    }
+
+    /**
+     * Create public failure.
+     * @param context Failure context
+     * @param timeout Whether timeout happened
+     * @param cause Root cause
+     * @return Failure
+     */
+    private static TogetherFailure failure(final FailureContext context,
+        final boolean timeout, final Throwable cause) {
+        return new RaisedFailure(context, new FailureKind(timeout, cause.getMessage()))
+            .asPublic(cause);
+    }
+}

--- a/src/main/java/com/yegor256/together/execution/package-info.java
+++ b/src/main/java/com/yegor256/together/execution/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Execution-time objects that represent started and completed work.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.execution;

--- a/src/main/java/com/yegor256/together/execution/package-info.java
+++ b/src/main/java/com/yegor256/together/execution/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Execution-time objects that represent started and completed work.
- *
  * @since 1.0
  */
 package com.yegor256.together.execution;

--- a/src/main/java/com/yegor256/together/failure/FailureContext.java
+++ b/src/main/java/com/yegor256/together/failure/FailureContext.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Failure context.
- *
  * @since 1.0
  */
 public final class FailureContext {

--- a/src/main/java/com/yegor256/together/failure/FailureContext.java
+++ b/src/main/java/com/yegor256/together/failure/FailureContext.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.failure;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Failure context.
+ *
+ * @since 1.0
+ */
+public final class FailureContext {
+
+    /**
+     * Round number.
+     */
+    private final int round;
+
+    /**
+     * Thread number.
+     */
+    private final int thread;
+
+    /**
+     * Elapsed time in milliseconds.
+     */
+    private final long elapsed;
+
+    /**
+     * Ctor.
+     * @param when Round number
+     * @param threadnum Thread number
+     * @param msec Elapsed time
+     */
+    public FailureContext(final int when, final int threadnum, final long msec) {
+        this.round = when;
+        this.thread = threadnum;
+        this.elapsed = msec;
+    }
+
+    /**
+     * Whether it happened in this round.
+     * @param number Round number
+     * @return TRUE if yes
+     */
+    public boolean happenedInRound(final int number) {
+        return this.round == number;
+    }
+
+    /**
+     * Whether it happened in this thread.
+     * @param number Thread number
+     * @return TRUE if yes
+     */
+    public boolean happenedInThread(final int number) {
+        return this.thread == number;
+    }
+
+    /**
+     * Whether it lasted at least this long.
+     * @param duration Duration
+     * @param unit Time unit
+     * @return TRUE if yes
+     */
+    public boolean lastedAtLeast(final long duration, final TimeUnit unit) {
+        return this.elapsed >= TimeUnit.MILLISECONDS.convert(duration, unit);
+    }
+
+    /**
+     * Build failure message.
+     * @param kind Failure kind
+     * @return Message
+     */
+    public String messageFor(final FailureKind kind) {
+        String text = String.format(
+            "Round #%d failed in thread #%d after %dms",
+            this.round, this.thread, this.elapsed
+        );
+        if (kind.causedByTimeout()) {
+            text = String.format("%s because timeout was exceeded", text);
+        } else if (kind.hasMessage()) {
+            text = String.format("%s: %s", text, kind.messageText());
+        }
+        return text;
+    }
+}

--- a/src/main/java/com/yegor256/together/failure/FailureDescription.java
+++ b/src/main/java/com/yegor256/together/failure/FailureDescription.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Failure description.
- *
  * @since 1.0
  */
 public final class FailureDescription {

--- a/src/main/java/com/yegor256/together/failure/FailureDescription.java
+++ b/src/main/java/com/yegor256/together/failure/FailureDescription.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.failure;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Failure description.
+ *
+ * @since 1.0
+ */
+public final class FailureDescription {
+
+    /**
+     * Failure context.
+     */
+    private final FailureContext context;
+
+    /**
+     * Failure kind.
+     */
+    private final FailureKind kind;
+
+    /**
+     * Ctor.
+     * @param details Failure context
+     * @param failure Failure kind
+     */
+    public FailureDescription(final FailureContext details,
+        final FailureKind failure) {
+        this.context = details;
+        this.kind = failure;
+    }
+
+    /**
+     * Message text.
+     * @return Message
+     */
+    public String messageText() {
+        return this.context.messageFor(this.kind);
+    }
+
+    /**
+     * Whether timeout caused this failure.
+     * @return TRUE if timeout happened
+     */
+    public boolean causedByTimeout() {
+        return this.kind.causedByTimeout();
+    }
+
+    /**
+     * Whether it happened in this round.
+     * @param number Round number
+     * @return TRUE if yes
+     */
+    public boolean happenedInRound(final int number) {
+        return this.context.happenedInRound(number);
+    }
+
+    /**
+     * Whether it happened in this thread.
+     * @param number Thread number
+     * @return TRUE if yes
+     */
+    public boolean happenedInThread(final int number) {
+        return this.context.happenedInThread(number);
+    }
+
+    /**
+     * Whether it lasted at least this long.
+     * @param duration Duration
+     * @param unit Time unit
+     * @return TRUE if yes
+     */
+    public boolean lastedAtLeast(final long duration, final TimeUnit unit) {
+        return this.context.lastedAtLeast(duration, unit);
+    }
+}

--- a/src/main/java/com/yegor256/together/failure/FailureKind.java
+++ b/src/main/java/com/yegor256/together/failure/FailureKind.java
@@ -6,7 +6,6 @@ package com.yegor256.together.failure;
 
 /**
  * Failure kind.
- *
  * @since 1.0
  */
 public final class FailureKind {

--- a/src/main/java/com/yegor256/together/failure/FailureKind.java
+++ b/src/main/java/com/yegor256/together/failure/FailureKind.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.failure;
+
+/**
+ * Failure kind.
+ *
+ * @since 1.0
+ */
+public final class FailureKind {
+
+    /**
+     * Whether timeout caused it.
+     */
+    private final boolean timeout;
+
+    /**
+     * Root message.
+     */
+    private final String message;
+
+    /**
+     * Ctor.
+     * @param exceeded Whether timeout happened
+     * @param text Root message
+     */
+    public FailureKind(final boolean exceeded, final String text) {
+        this.timeout = exceeded;
+        this.message = text;
+    }
+
+    /**
+     * Whether timeout caused this failure.
+     * @return TRUE if timeout happened
+     */
+    public boolean causedByTimeout() {
+        return this.timeout;
+    }
+
+    /**
+     * Whether the cause has message.
+     * @return TRUE if it has one
+     */
+    public boolean hasMessage() {
+        return this.message != null;
+    }
+
+    /**
+     * Message text.
+     * @return Message
+     */
+    public String messageText() {
+        String text = "";
+        if (this.message != null) {
+            text = this.message;
+        }
+        return text;
+    }
+}

--- a/src/main/java/com/yegor256/together/failure/RaisedFailure.java
+++ b/src/main/java/com/yegor256/together/failure/RaisedFailure.java
@@ -8,7 +8,6 @@ import com.yegor256.TogetherFailure;
 
 /**
  * Raised failure.
- *
  * @since 1.0
  */
 public final class RaisedFailure {

--- a/src/main/java/com/yegor256/together/failure/RaisedFailure.java
+++ b/src/main/java/com/yegor256/together/failure/RaisedFailure.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.failure;
+
+import com.yegor256.TogetherFailure;
+
+/**
+ * Raised failure.
+ *
+ * @since 1.0
+ */
+public final class RaisedFailure {
+
+    /**
+     * Failure context.
+     */
+    private final FailureContext context;
+
+    /**
+     * Failure kind.
+     */
+    private final FailureKind kind;
+
+    /**
+     * Ctor.
+     * @param details Failure context
+     * @param failure Failure kind
+     */
+    public RaisedFailure(final FailureContext details, final FailureKind failure) {
+        this.context = details;
+        this.kind = failure;
+    }
+
+    /**
+     * Convert to public failure.
+     * @param cause Root cause
+     * @return Failure
+     */
+    public TogetherFailure asPublic(final Throwable cause) {
+        return new TogetherFailure(this.context, this.kind, cause);
+    }
+}

--- a/src/main/java/com/yegor256/together/failure/package-info.java
+++ b/src/main/java/com/yegor256/together/failure/package-info.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
 /**
  * Failure objects.
  *

--- a/src/main/java/com/yegor256/together/failure/package-info.java
+++ b/src/main/java/com/yegor256/together/failure/package-info.java
@@ -4,7 +4,6 @@
  */
 /**
  * Failure objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.failure;

--- a/src/main/java/com/yegor256/together/failure/package-info.java
+++ b/src/main/java/com/yegor256/together/failure/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Failure objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.failure;

--- a/src/main/java/com/yegor256/together/package-info.java
+++ b/src/main/java/com/yegor256/together/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Internal bounded contexts for concurrent race execution.
- *
  * @since 1.0
  */
 package com.yegor256.together;

--- a/src/main/java/com/yegor256/together/package-info.java
+++ b/src/main/java/com/yegor256/together/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Internal bounded contexts for concurrent race execution.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together;

--- a/src/main/java/com/yegor256/together/policy/Deadline.java
+++ b/src/main/java/com/yegor256/together/policy/Deadline.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Timeout deadline.
- *
  * @since 1.0
  */
 public final class Deadline {

--- a/src/main/java/com/yegor256/together/policy/Deadline.java
+++ b/src/main/java/com/yegor256/together/policy/Deadline.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Timeout deadline.
+ *
+ * @since 1.0
+ */
+public final class Deadline {
+
+    /**
+     * Timeout.
+     */
+    private final long limit;
+
+    /**
+     * Unit.
+     */
+    private final TimeUnit unit;
+
+    /**
+     * Ctor.
+     * @param timeout Timeout
+     * @param tunit Time unit
+     */
+    public Deadline(final long timeout, final TimeUnit tunit) {
+        // @checkstyle ConstructorsCodeFreeCheck (3 lines)
+        if (timeout < 1L) {
+            throw new IllegalArgumentException(
+                String.format("Timeout must be positive: %d", timeout)
+            );
+        }
+        this.limit = timeout;
+        this.unit = tunit;
+    }
+
+    /**
+     * Remaining timeout.
+     * @param start Start time
+     * @return Remaining timeout
+     */
+    public long from(final long start) {
+        return Math.max(
+            1L,
+            this.limit - this.unit.convert(
+                System.nanoTime() - start,
+                TimeUnit.NANOSECONDS
+            )
+        );
+    }
+
+    /**
+     * Time unit.
+     * @return Unit
+     */
+    public TimeUnit timeUnit() {
+        return this.unit;
+    }
+}

--- a/src/main/java/com/yegor256/together/policy/Forever.java
+++ b/src/main/java/com/yegor256/together/policy/Forever.java
@@ -10,7 +10,6 @@ import com.yegor256.together.execution.Started;
 
 /**
  * Wait forever.
- *
  * @since 1.0
  */
 public final class Forever implements Patience {

--- a/src/main/java/com/yegor256/together/policy/Forever.java
+++ b/src/main/java/com/yegor256/together/policy/Forever.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Execution;
+import com.yegor256.together.execution.Started;
+
+/**
+ * Wait forever.
+ *
+ * @since 1.0
+ */
+public final class Forever implements Patience {
+
+    @Override
+    public <T> Execution<T> waitFor(final Completed<T> completed, final int round,
+        final Started<T> started) {
+        return started.next(round);
+    }
+}

--- a/src/main/java/com/yegor256/together/policy/Limited.java
+++ b/src/main/java/com/yegor256/together/policy/Limited.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Execution;
+import com.yegor256.together.execution.Started;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Limited waiting time.
+ *
+ * @since 1.0
+ */
+public final class Limited implements Patience {
+
+    /**
+     * Deadline.
+     */
+    private final Deadline deadline;
+
+    /**
+     * Ctor.
+     * @param timeout Timeout
+     * @param tunit Unit
+     */
+    public Limited(final long timeout, final TimeUnit tunit) {
+        // @checkstyle ConstructorsCodeFreeCheck (1 line)
+        this(new Deadline(timeout, tunit));
+    }
+
+    /**
+     * Private ctor.
+     * @param time Deadline
+     */
+    private Limited(final Deadline time) {
+        this.deadline = time;
+    }
+
+    @Override
+    public <T> Execution<T> waitFor(final Completed<T> completed, final int round,
+        final Started<T> started) {
+        return started.next(round, this.deadline, completed.missingThread());
+    }
+}

--- a/src/main/java/com/yegor256/together/policy/Limited.java
+++ b/src/main/java/com/yegor256/together/policy/Limited.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Limited waiting time.
- *
  * @since 1.0
  */
 public final class Limited implements Patience {

--- a/src/main/java/com/yegor256/together/policy/Patience.java
+++ b/src/main/java/com/yegor256/together/policy/Patience.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Execution;
+import com.yegor256.together.execution.Started;
+
+/**
+ * How long to wait.
+ *
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface Patience {
+
+    /**
+     * Wait for the next execution.
+     * @param completed Completed executions
+     * @param round Round number
+     * @param started Started execution
+     * @param <T> Type of result
+     * @return Next execution
+     */
+    <T> Execution<T> waitFor(Completed<T> completed, int round, Started<T> started);
+}

--- a/src/main/java/com/yegor256/together/policy/Patience.java
+++ b/src/main/java/com/yegor256/together/policy/Patience.java
@@ -10,7 +10,6 @@ import com.yegor256.together.execution.Started;
 
 /**
  * How long to wait.
- *
  * @since 1.0
  */
 @FunctionalInterface

--- a/src/main/java/com/yegor256/together/policy/Reaction.java
+++ b/src/main/java/com/yegor256/together/policy/Reaction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Started;
+
+/**
+ * Reaction to the next completed execution.
+ *
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface Reaction {
+
+    /**
+     * React to the next state.
+     * @param round Round number
+     * @param started Started execution
+     * @param completed Completed executions
+     * @param <T> Type of result
+     */
+    <T> void reactTo(int round, Started<T> started, Completed<T> completed);
+}

--- a/src/main/java/com/yegor256/together/policy/Reaction.java
+++ b/src/main/java/com/yegor256/together/policy/Reaction.java
@@ -9,7 +9,6 @@ import com.yegor256.together.execution.Started;
 
 /**
  * Reaction to the next completed execution.
- *
  * @since 1.0
  */
 @FunctionalInterface

--- a/src/main/java/com/yegor256/together/policy/StopFast.java
+++ b/src/main/java/com/yegor256/together/policy/StopFast.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Started;
+
+/**
+ * Stop on the first failure.
+ *
+ * @since 1.0
+ */
+public final class StopFast implements Reaction {
+
+    @Override
+    public <T> void reactTo(final int round, final Started<T> started,
+        final Completed<T> completed) {
+        completed.stopFastIn(round, started);
+    }
+}

--- a/src/main/java/com/yegor256/together/policy/StopFast.java
+++ b/src/main/java/com/yegor256/together/policy/StopFast.java
@@ -9,7 +9,6 @@ import com.yegor256.together.execution.Started;
 
 /**
  * Stop on the first failure.
- *
  * @since 1.0
  */
 public final class StopFast implements Reaction {

--- a/src/main/java/com/yegor256/together/policy/WaitForAll.java
+++ b/src/main/java/com/yegor256/together/policy/WaitForAll.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Started;
+
+/**
+ * Keep waiting for all threads.
+ *
+ * @since 1.0
+ */
+public final class WaitForAll implements Reaction {
+
+    @Override
+    public <T> void reactTo(final int round, final Started<T> started,
+        final Completed<T> completed) {
+        // Intentionally empty.
+    }
+}

--- a/src/main/java/com/yegor256/together/policy/WaitForAll.java
+++ b/src/main/java/com/yegor256/together/policy/WaitForAll.java
@@ -9,7 +9,6 @@ import com.yegor256.together.execution.Started;
 
 /**
  * Keep waiting for all threads.
- *
  * @since 1.0
  */
 public final class WaitForAll implements Reaction {

--- a/src/main/java/com/yegor256/together/policy/Watching.java
+++ b/src/main/java/com/yegor256/together/policy/Watching.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Watching policy.
- *
  * @since 1.0
  */
 public final class Watching {

--- a/src/main/java/com/yegor256/together/policy/Watching.java
+++ b/src/main/java/com/yegor256/together/policy/Watching.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Started;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Watching policy.
+ *
+ * @since 1.0
+ */
+public final class Watching {
+
+    /**
+     * Patience.
+     */
+    private final Patience patience;
+
+    /**
+     * Reaction.
+     */
+    private final Reaction reaction;
+
+    /**
+     * Ctor.
+     */
+    public Watching() {
+        this(
+            new com.yegor256.together.policy.Forever(),
+            new com.yegor256.together.policy.WaitForAll()
+        );
+    }
+
+    /**
+     * Private ctor.
+     * @param wait Patience
+     * @param react Reaction
+     */
+    private Watching(final Patience wait, final Reaction react) {
+        this.patience = wait;
+        this.reaction = react;
+    }
+
+    /**
+     * Add timeout.
+     * @param limit Timeout
+     * @param unit Unit
+     * @return New policy
+     */
+    public Watching withTimeout(final long limit, final TimeUnit unit) {
+        return new com.yegor256.together.policy.Watching(
+            new com.yegor256.together.policy.Limited(limit, unit), this.reaction
+        );
+    }
+
+    /**
+     * Stop fast.
+     * @return New policy
+     */
+    public Watching failFast() {
+        return new com.yegor256.together.policy.Watching(
+            this.patience, new com.yegor256.together.policy.StopFast()
+        );
+    }
+
+    /**
+     * Collect all results.
+     * @param round Round number
+     * @param completed Completed executions
+     * @param started Started execution
+     * @param <T> Type of result
+     * @return Results
+     */
+    public <T> List<T> collectFrom(final int round, final Completed<T> completed,
+        final Started<T> started) {
+        started.start();
+        while (completed.isIncomplete()) {
+            this.reaction.reactTo(
+                round, started,
+                completed.with(this.patience.waitFor(completed, round, started))
+            );
+        }
+        return completed.resultsIn(round);
+    }
+}

--- a/src/main/java/com/yegor256/together/policy/package-info.java
+++ b/src/main/java/com/yegor256/together/policy/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Policies that decide how the race is watched.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.policy;

--- a/src/main/java/com/yegor256/together/policy/package-info.java
+++ b/src/main/java/com/yegor256/together/policy/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Policies that decide how the race is watched.
- *
  * @since 1.0
  */
 package com.yegor256.together.policy;

--- a/src/main/java/com/yegor256/together/race/Race.java
+++ b/src/main/java/com/yegor256/together/race/Race.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Concurrent race.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/race/Race.java
+++ b/src/main/java/com/yegor256/together/race/Race.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import com.yegor256.Together;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Concurrent race.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Race<T> implements Iterable<T> {
+
+    /**
+     * Default amount of threads.
+     */
+    private static final int DEFAULT =
+        Math.max(Runtime.getRuntime().availableProcessors(), 3);
+
+    /**
+     * Scenario.
+     */
+    private final Scenario<T> scenario;
+
+    /**
+     * Rules.
+     */
+    private final Rules rules;
+
+    /**
+     * Ctor.
+     * @param action Action
+     */
+    public Race(final Together.Action<T> action) {
+        this(Race.DEFAULT, action);
+    }
+
+    /**
+     * Ctor.
+     * @param total Threads
+     * @param action Action
+     */
+    public Race(final int total, final Together.Action<T> action) {
+        this(new Scenario<>(new Threads(total), action), new Rules());
+    }
+
+    /**
+     * Private ctor.
+     * @param origin Scenario
+     * @param law Rules
+     */
+    private Race(final Scenario<T> origin, final Rules law) {
+        this.scenario = origin;
+        this.rules = law;
+    }
+
+    /**
+     * Repeat it.
+     * @param total Rounds
+     * @return New race
+     */
+    public Race<T> repeated(final int total) {
+        return new com.yegor256.together.race.Race<>(
+            this.scenario, this.rules.repeated(total)
+        );
+    }
+
+    /**
+     * Limit its duration.
+     * @param limit Timeout
+     * @param unit Unit
+     * @return New race
+     */
+    public Race<T> withTimeout(final long limit, final TimeUnit unit) {
+        return new com.yegor256.together.race.Race<>(
+            this.scenario, this.rules.withTimeout(limit, unit)
+        );
+    }
+
+    /**
+     * Stop fast.
+     * @return New race
+     */
+    public Race<T> failFast() {
+        return new com.yegor256.together.race.Race<>(
+            this.scenario, this.rules.failFast()
+        );
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new com.yegor256.together.support.Iter<>(this.asList());
+    }
+
+    /**
+     * Convert to list.
+     * @return Results
+     */
+    public List<T> asList() {
+        final ExecutorService service = this.scenario.newService();
+        try {
+            return this.rules.resultsOf(this.scenario, service);
+        } finally {
+            new com.yegor256.together.support.Shutdown(service).finish();
+        }
+    }
+}

--- a/src/main/java/com/yegor256/together/race/Round.java
+++ b/src/main/java/com/yegor256/together/race/Round.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import com.yegor256.together.policy.Watching;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * One round of the race.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Round<T> {
+
+    /**
+     * Scenario.
+     */
+    private final Scenario<T> scenario;
+
+    /**
+     * Watching policy.
+     */
+    private final Watching watching;
+
+    /**
+     * Ctor.
+     * @param origin Scenario
+     * @param policy Watching policy
+     */
+    public Round(final Scenario<T> origin, final Watching policy) {
+        this.scenario = origin;
+        this.watching = policy;
+    }
+
+    /**
+     * Execute the round.
+     * @param service Executor service
+     * @param number Round number
+     * @return Results
+     */
+    public List<T> resultsOn(final ExecutorService service, final int number) {
+        return this.watching.collectFrom(
+            number,
+            this.scenario.newCompleted(),
+            this.scenario.startedOn(service)
+        );
+    }
+}

--- a/src/main/java/com/yegor256/together/race/Round.java
+++ b/src/main/java/com/yegor256/together/race/Round.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutorService;
 
 /**
  * One round of the race.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/race/Rounds.java
+++ b/src/main/java/com/yegor256/together/race/Rounds.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import java.util.Iterator;
+import java.util.stream.IntStream;
+
+/**
+ * Round numbers.
+ *
+ * @since 1.0
+ */
+public final class Rounds implements Iterable<Integer> {
+
+    /**
+     * Total rounds.
+     */
+    private final int total;
+
+    /**
+     * Ctor.
+     * @param count Total rounds
+     */
+    public Rounds(final int count) {
+        // @checkstyle ConstructorsCodeFreeCheck (3 lines)
+        if (count < 1) {
+            throw new IllegalArgumentException(
+                String.format("Number of rounds must be positive: %d", count)
+            );
+        }
+        this.total = count;
+    }
+
+    @Override
+    public Iterator<Integer> iterator() {
+        return IntStream.range(0, this.total).boxed().iterator();
+    }
+}

--- a/src/main/java/com/yegor256/together/race/Rounds.java
+++ b/src/main/java/com/yegor256/together/race/Rounds.java
@@ -9,7 +9,6 @@ import java.util.stream.IntStream;
 
 /**
  * Round numbers.
- *
  * @since 1.0
  */
 public final class Rounds implements Iterable<Integer> {

--- a/src/main/java/com/yegor256/together/race/Rules.java
+++ b/src/main/java/com/yegor256/together/race/Rules.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Rules of the race.
- *
  * @since 1.0
  */
 public final class Rules {

--- a/src/main/java/com/yegor256/together/race/Rules.java
+++ b/src/main/java/com/yegor256/together/race/Rules.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import com.yegor256.together.policy.Watching;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Rules of the race.
+ *
+ * @since 1.0
+ */
+public final class Rules {
+
+    /**
+     * Rounds.
+     */
+    private final Rounds rounds;
+
+    /**
+     * Watching policy.
+     */
+    private final Watching watching;
+
+    /**
+     * Ctor.
+     */
+    public Rules() {
+        this(
+            new com.yegor256.together.race.Rounds(1),
+            new com.yegor256.together.policy.Watching()
+        );
+    }
+
+    /**
+     * Private ctor.
+     * @param every Rounds
+     * @param policy Watching policy
+     */
+    private Rules(final Rounds every, final Watching policy) {
+        this.rounds = every;
+        this.watching = policy;
+    }
+
+    /**
+     * Repeat more times.
+     * @param total Number of rounds
+     * @return New rules
+     */
+    public Rules repeated(final int total) {
+        return new com.yegor256.together.race.Rules(
+            new com.yegor256.together.race.Rounds(total), this.watching
+        );
+    }
+
+    /**
+     * Limit time.
+     * @param limit Timeout
+     * @param unit Unit
+     * @return New rules
+     */
+    public Rules withTimeout(final long limit, final TimeUnit unit) {
+        return new com.yegor256.together.race.Rules(
+            this.rounds, this.watching.withTimeout(limit, unit)
+        );
+    }
+
+    /**
+     * Stop fast.
+     * @return New rules
+     */
+    public Rules failFast() {
+        return new com.yegor256.together.race.Rules(
+            this.rounds, this.watching.failFast()
+        );
+    }
+
+    /**
+     * Execute all rounds.
+     * @param scenario Scenario
+     * @param service Executor service
+     * @param <T> Type of result
+     * @return Results
+     */
+    public <T> List<T> resultsOf(final Scenario<T> scenario,
+        final ExecutorService service) {
+        final List<T> results = new LinkedList<>();
+        for (final Integer round : this.rounds) {
+            results.addAll(
+                new com.yegor256.together.race.Round<>(scenario, this.watching)
+                    .resultsOn(service, round)
+            );
+        }
+        return results;
+    }
+}

--- a/src/main/java/com/yegor256/together/race/Scenario.java
+++ b/src/main/java/com/yegor256/together/race/Scenario.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Future;
 
 /**
  * Race scenario.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/race/Scenario.java
+++ b/src/main/java/com/yegor256/together/race/Scenario.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import com.yegor256.Together;
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Execution;
+import com.yegor256.together.execution.Job;
+import com.yegor256.together.execution.Started;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+/**
+ * Race scenario.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Scenario<T> {
+
+    /**
+     * Threads.
+     */
+    private final Threads threads;
+
+    /**
+     * Action.
+     */
+    private final Together.Action<T> action;
+
+    /**
+     * Ctor.
+     * @param total Threads
+     * @param job Action
+     */
+    public Scenario(final Threads total, final Together.Action<T> job) {
+        // @checkstyle ConstructorsCodeFreeCheck (1 line)
+        this.threads = total.copy();
+        this.action = job;
+    }
+
+    /**
+     * New service.
+     * @return Executor service
+     */
+    public ExecutorService newService() {
+        return this.threads.newService();
+    }
+
+    /**
+     * Submit all jobs.
+     * @param service Executor service
+     * @return Started execution
+     */
+    public Started<T> startedOn(final ExecutorService service) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Map<Integer, Future<Execution<T>>> futures = new HashMap<>();
+        final ExecutorCompletionService<Execution<T>> completion =
+            new ExecutorCompletionService<>(service);
+        for (final int thread : this.threads.inRandomOrder()) {
+            futures.put(
+                thread,
+                completion.submit(new Job<>(latch, thread, this.action))
+            );
+        }
+        return new Started<>(latch, completion, futures);
+    }
+
+    /**
+     * New completion collector.
+     * @return Collector
+     */
+    public Completed<T> newCompleted() {
+        return new Completed<>(this.threads);
+    }
+}

--- a/src/main/java/com/yegor256/together/race/Threads.java
+++ b/src/main/java/com/yegor256/together/race/Threads.java
@@ -14,7 +14,6 @@ import java.util.concurrent.Executors;
 
 /**
  * Thread numbers.
- *
  * @since 1.0
  */
 public final class Threads {

--- a/src/main/java/com/yegor256/together/race/Threads.java
+++ b/src/main/java/com/yegor256/together/race/Threads.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import com.yegor256.together.execution.Execution;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Thread numbers.
+ *
+ * @since 1.0
+ */
+public final class Threads {
+
+    /**
+     * Total threads.
+     */
+    private final int total;
+
+    /**
+     * Ctor.
+     * @param count Number of threads
+     */
+    public Threads(final int count) {
+        this.total = count;
+    }
+
+    /**
+     * Create executor service.
+     * @return Service
+     */
+    public ExecutorService newService() {
+        return Executors.newFixedThreadPool(this.total);
+    }
+
+    /**
+     * Copy itself.
+     * @return Copy
+     */
+    public Threads copy() {
+        return new com.yegor256.together.race.Threads(this.total);
+    }
+
+    /**
+     * Thread numbers in random order.
+     * @return Numbers
+     */
+    public Iterable<Integer> inRandomOrder() {
+        final List<Integer> numbers = new ArrayList<>(this.total);
+        for (int idx = 0; idx < this.total; ++idx) {
+            numbers.add(idx);
+        }
+        Collections.shuffle(numbers);
+        return numbers;
+    }
+
+    /**
+     * Whether some threads are still missing.
+     * @param done Completed executions
+     * @return TRUE if some are missing
+     */
+    public boolean misses(final Map<Integer, Execution<?>> done) {
+        return done.size() < this.total;
+    }
+
+    /**
+     * Find first absent thread.
+     * @param done Completed executions
+     * @return Missing thread
+     */
+    public int firstAbsentFrom(final Map<Integer, Execution<?>> done) {
+        int thread = -1;
+        for (int idx = 0; idx < this.total; ++idx) {
+            if (!done.containsKey(idx)) {
+                thread = idx;
+                break;
+            }
+        }
+        return thread;
+    }
+
+    /**
+     * Add all results in order.
+     * @param done Completed executions
+     * @param round Round number
+     * @param results Mutable results
+     * @param <T> Type of result
+     */
+    public <T> void appendTo(final Map<Integer, Execution<T>> done,
+        final int round, final List<T> results) {
+        for (int idx = 0; idx < this.total; ++idx) {
+            done.get(idx).complete(round, results);
+        }
+    }
+}

--- a/src/main/java/com/yegor256/together/race/package-info.java
+++ b/src/main/java/com/yegor256/together/race/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Race aggregate and orchestration objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.race;

--- a/src/main/java/com/yegor256/together/race/package-info.java
+++ b/src/main/java/com/yegor256/together/race/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Race aggregate and orchestration objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.race;

--- a/src/main/java/com/yegor256/together/support/Iter.java
+++ b/src/main/java/com/yegor256/together/support/Iter.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 /**
  * Iterator with informative {@link #toString()}.
- *
  * @param <T> Type of result
  * @since 1.0
  */

--- a/src/main/java/com/yegor256/together/support/Iter.java
+++ b/src/main/java/com/yegor256/together/support/Iter.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.support;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Iterator with informative {@link #toString()}.
+ *
+ * @param <T> Type of result
+ * @since 1.0
+ */
+public final class Iter<T> implements java.util.Iterator<T> {
+
+    /**
+     * Items.
+     */
+    private final List<T> items;
+
+    /**
+     * Current position.
+     */
+    private int position;
+
+    /**
+     * Ctor.
+     * @param all Items
+     */
+    public Iter(final Collection<T> all) {
+        this.items = new ArrayList<>(all);
+        this.position = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.position < this.items.size();
+    }
+
+    @Override
+    public T next() {
+        this.position = this.position + 1;
+        return this.items.get(this.position - 1);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder text = new StringBuilder(16).append('[');
+        for (final T item : this.items) {
+            if (text.length() > 1) {
+                text.append(", ");
+            }
+            text.append(item);
+        }
+        return text.append(']').toString();
+    }
+}

--- a/src/main/java/com/yegor256/together/support/Shutdown.java
+++ b/src/main/java/com/yegor256/together/support/Shutdown.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.support;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executor shutdown.
+ *
+ * @since 1.0
+ */
+public final class Shutdown {
+
+    /**
+     * Executor service.
+     */
+    private final ExecutorService service;
+
+    /**
+     * Ctor.
+     * @param origin Service
+     */
+    public Shutdown(final ExecutorService origin) {
+        this.service = origin;
+    }
+
+    /**
+     * Shutdown it.
+     */
+    public void finish() {
+        this.service.shutdown();
+        try {
+            if (!this.service.awaitTermination(1L, TimeUnit.MINUTES)) {
+                this.service.shutdownNow();
+                if (!this.service.awaitTermination(1L, TimeUnit.MINUTES)) {
+                    throw new IllegalStateException("Can't shutdown");
+                }
+            }
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException(ex);
+        }
+    }
+}

--- a/src/main/java/com/yegor256/together/support/Shutdown.java
+++ b/src/main/java/com/yegor256/together/support/Shutdown.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Executor shutdown.
- *
  * @since 1.0
  */
 public final class Shutdown {

--- a/src/main/java/com/yegor256/together/support/package-info.java
+++ b/src/main/java/com/yegor256/together/support/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Supporting infrastructure objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.support;

--- a/src/main/java/com/yegor256/together/support/package-info.java
+++ b/src/main/java/com/yegor256/together/support/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Supporting infrastructure objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.support;

--- a/src/test/java/com/yegor256/TogetherFailureTest.java
+++ b/src/test/java/com/yegor256/TogetherFailureTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link TogetherFailure}.
- *
  * @since 1.0
  */
 final class TogetherFailureTest {

--- a/src/test/java/com/yegor256/TogetherFailureTest.java
+++ b/src/test/java/com/yegor256/TogetherFailureTest.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256;
+
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link TogetherFailure}.
+ *
+ * @since 1.0
+ */
+final class TogetherFailureTest {
+
+    /**
+     * Error text.
+     */
+    private static final String TEXT = "boom";
+
+    /**
+     * Failure context.
+     */
+    private static final com.yegor256.together.failure.FailureContext CONTEXT =
+        new com.yegor256.together.failure.FailureContext(2, 7, 15L);
+
+    @Test
+    void recognizesTimeout() {
+        MatcherAssert.assertThat(
+            "must recognize timeout",
+            new TogetherFailure(
+                TogetherFailureTest.CONTEXT,
+                new com.yegor256.together.failure.FailureKind(
+                    true, TogetherFailureTest.TEXT
+                ),
+                new IllegalStateException(TogetherFailureTest.TEXT)
+            ).causedByTimeout(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void recognizesRound() {
+        MatcherAssert.assertThat(
+            "must recognize round",
+            new TogetherFailure(
+                TogetherFailureTest.CONTEXT,
+                new com.yegor256.together.failure.FailureKind(
+                    true, TogetherFailureTest.TEXT
+                ),
+                new IllegalStateException(TogetherFailureTest.TEXT)
+            ).happenedInRound(2),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void recognizesThread() {
+        MatcherAssert.assertThat(
+            "must recognize thread",
+            new TogetherFailure(
+                TogetherFailureTest.CONTEXT,
+                new com.yegor256.together.failure.FailureKind(
+                    true, TogetherFailureTest.TEXT
+                ),
+                new IllegalStateException(TogetherFailureTest.TEXT)
+            ).happenedInThread(7),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void comparesElapsedTime() {
+        MatcherAssert.assertThat(
+            "must compare elapsed time",
+            new TogetherFailure(
+                TogetherFailureTest.CONTEXT,
+                new com.yegor256.together.failure.FailureKind(
+                    true, TogetherFailureTest.TEXT
+                ),
+                new IllegalStateException(TogetherFailureTest.TEXT)
+            ).lastedAtLeast(10L, TimeUnit.MILLISECONDS),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsDifferentFailureLocation() {
+        final TogetherFailure failure = new TogetherFailure(
+            TogetherFailureTest.CONTEXT,
+            new com.yegor256.together.failure.FailureKind(false, (String) null),
+            new IllegalStateException(TogetherFailureTest.TEXT)
+        );
+        MatcherAssert.assertThat(
+            "must reject different round and thread",
+            failure.causedByTimeout()
+                || failure.happenedInRound(3)
+                || failure.happenedInThread(8)
+                || failure.lastedAtLeast(16L, TimeUnit.MILLISECONDS),
+            Matchers.is(false)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/TogetherTest.java
+++ b/src/test/java/com/yegor256/TogetherTest.java
@@ -5,6 +5,7 @@
 package com.yegor256;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.1.0
  */
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnnecessaryLocalRule"})
 final class TogetherTest {
 
     @Test
@@ -72,14 +74,19 @@ final class TogetherTest {
 
     @Test
     void failsInAllThreads() {
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
+        final TogetherFailure failure = Assertions.assertThrows(
+            TogetherFailure.class,
             () -> new Together<>(
                 t -> {
                     throw new IllegalArgumentException("intended");
                 }
             ).asList(),
             "doesn't fail when one of the threads fails"
+        );
+        MatcherAssert.assertThat(
+            "must report the failed round",
+            failure.happenedInRound(0),
+            Matchers.is(true)
         );
     }
 
@@ -171,6 +178,71 @@ final class TogetherTest {
                     .boxed()
                     .toArray(Integer[]::new)
             )
+        );
+    }
+
+    @Test
+    void repeatsAllRounds() {
+        MatcherAssert.assertThat(
+            "must execute the same race more than once",
+            new Together<>(
+                3,
+                t -> t
+            ).repeated(2).asList(),
+            Matchers.contains(0, 1, 2, 0, 1, 2)
+        );
+    }
+
+    @Test
+    void failsWhenRoundTimeoutIsExceeded() {
+        final TogetherFailure failure = Assertions.assertThrows(
+            TogetherFailure.class,
+            () -> new Together<>(
+                1,
+                t -> {
+                    Thread.sleep(100L);
+                    return t;
+                }
+            ).withTimeout(10L, TimeUnit.MILLISECONDS).asList(),
+            "must fail when a round exceeds timeout"
+        );
+        MatcherAssert.assertThat(
+            "must mark timeout failures clearly",
+            failure.causedByTimeout(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void interruptsRemainingThreadsInFailFastMode() throws InterruptedException {
+        final CountDownLatch entered = new CountDownLatch(1);
+        final CountDownLatch interrupted = new CountDownLatch(1);
+        Assertions.assertThrows(
+            TogetherFailure.class,
+            () -> new Together<>(
+                2,
+                t -> {
+                    if (t == 0) {
+                        entered.await(1L, TimeUnit.SECONDS);
+                        throw new IllegalStateException("boom");
+                    }
+                    try {
+                        entered.countDown();
+                        Thread.sleep(100_000L);
+                    } catch (final InterruptedException ex) {
+                        interrupted.countDown();
+                        throw ex;
+                    }
+                    return t;
+                }
+            ).failFast().asList(),
+            "must fail fast when one thread breaks"
+        );
+        entered.await(1L, TimeUnit.SECONDS);
+        MatcherAssert.assertThat(
+            "must interrupt the remaining thread",
+            interrupted.await(1L, TimeUnit.SECONDS),
+            Matchers.is(true)
         );
     }
 }

--- a/src/test/java/com/yegor256/TogetherTest.java
+++ b/src/test/java/com/yegor256/TogetherTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Together}.
- *
  * @since 0.1.0
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.UnnecessaryLocalRule"})

--- a/src/test/java/com/yegor256/package-info.java
+++ b/src/test/java/com/yegor256/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests for the main class.
- *
  * @since 0.0.1
  */
 package com.yegor256;

--- a/src/test/java/com/yegor256/together/execution/CompletedTest.java
+++ b/src/test/java/com/yegor256/together/execution/CompletedTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Completed}.
- *
  * @since 1.0
  */
 final class CompletedTest {
@@ -38,8 +37,7 @@ final class CompletedTest {
         Assertions.assertThrows(
             TogetherFailure.class,
             () -> new Completed<Integer>(new Threads(1))
-                .with(new Execution<>(0, new IllegalStateException("boom"), 0L))
-                .stopFastIn(
+                .with(new Execution<>(0, new IllegalStateException("boom"), 0L)).stopFastIn(
                     0,
                     new Started<>(
                         new java.util.concurrent.CountDownLatch(0),

--- a/src/test/java/com/yegor256/together/execution/CompletedTest.java
+++ b/src/test/java/com/yegor256/together/execution/CompletedTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import com.yegor256.TogetherFailure;
+import com.yegor256.together.race.Threads;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Completed}.
+ *
+ * @since 1.0
+ */
+final class CompletedTest {
+
+    @Test
+    void collectsAndOrdersResults() {
+        MatcherAssert.assertThat(
+            "must collect results in thread order",
+            new Completed<Integer>(new Threads(2))
+                .with(new Execution<>(1, 11, 0L))
+                .with(new Execution<>(0, 7, 0L))
+                .resultsIn(0),
+            Matchers.contains(7, 11)
+        );
+    }
+
+    @Test
+    void stopsFastOnFailure() {
+        Assertions.assertThrows(
+            TogetherFailure.class,
+            () -> new Completed<Integer>(new Threads(1))
+                .with(new Execution<>(0, new IllegalStateException("boom"), 0L))
+                .stopFastIn(
+                    0,
+                    new Started<>(
+                        new java.util.concurrent.CountDownLatch(0),
+                        new ExecutorCompletionService<>(Executors.newSingleThreadExecutor()),
+                        new HashMap<>()
+                    )
+                ),
+            "must stop on failure"
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/execution/ExecutionTest.java
+++ b/src/test/java/com/yegor256/together/execution/ExecutionTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Execution}.
- *
  * @since 1.0
  */
 final class ExecutionTest {

--- a/src/test/java/com/yegor256/together/execution/ExecutionTest.java
+++ b/src/test/java/com/yegor256/together/execution/ExecutionTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import com.yegor256.TogetherFailure;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Execution}.
+ *
+ * @since 1.0
+ */
+final class ExecutionTest {
+
+    @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void placesAndCompletesSuccessfulExecution() {
+        final Map<Integer, Execution<Integer>> all = new java.util.TreeMap<>();
+        final List<Integer> results = new java.util.ArrayList<>(1);
+        final Execution<Integer> execution = new Execution<>(0, 42, 1L);
+        execution.placeInto(all);
+        execution.complete(0, results);
+        MatcherAssert.assertThat(
+            "must place and complete value",
+            results,
+            Matchers.contains(42)
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void convertsFailureToPublicException() {
+        final TogetherFailure failure = Assertions.assertThrows(
+            TogetherFailure.class,
+            () -> new Execution<Integer>(
+                3, new IllegalStateException("boom"), 2L
+            ).complete(5, new java.util.ArrayList<Integer>(1)),
+            "must convert failure to public exception"
+        );
+        MatcherAssert.assertThat(
+            "must keep round information",
+            failure.happenedInRound(5),
+            Matchers.is(true)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/execution/JobTest.java
+++ b/src/test/java/com/yegor256/together/execution/JobTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Job}.
+ *
+ * @since 1.0
+ */
+final class JobTest {
+
+    @Test
+    void executesAction() throws Exception {
+        final Job<Integer> job = new Job<>(
+            new CountDownLatch(0),
+            3,
+            thread -> thread * 2
+        );
+        final List<Integer> results = new java.util.ArrayList<>(1);
+        job.call().complete(0, results);
+        MatcherAssert.assertThat(
+            "must execute action result",
+            results,
+            Matchers.contains(6)
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+    void waitsForLatchBeforeExecution() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+            final Future<Execution<Integer>> future = service.submit(
+                new Job<>(latch, 3, thread -> thread * 2)
+            );
+            MatcherAssert.assertThat(
+                "must wait for latch release",
+                future.isDone(),
+                Matchers.is(false)
+            );
+            latch.countDown();
+            final List<Integer> results = new java.util.ArrayList<>(1);
+            future.get().complete(0, results);
+            MatcherAssert.assertThat(
+                "must execute after latch release",
+                results,
+                Matchers.contains(6)
+            );
+        }
+    }
+}

--- a/src/test/java/com/yegor256/together/execution/JobTest.java
+++ b/src/test/java/com/yegor256/together/execution/JobTest.java
@@ -37,10 +37,11 @@ final class JobTest {
     }
 
     @Test
-    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+    @SuppressWarnings({"PMD.UnitTestContainsTooManyAsserts", "PMD.CloseResource"})
     void waitsForLatchBeforeExecution() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+        final ExecutorService service = Executors.newSingleThreadExecutor();
+        try {
             final Future<Execution<Integer>> future = service.submit(
                 new Job<>(latch, 3, thread -> thread * 2)
             );
@@ -57,6 +58,8 @@ final class JobTest {
                 results,
                 Matchers.contains(6)
             );
+        } finally {
+            new com.yegor256.together.support.Shutdown(service).finish();
         }
     }
 }

--- a/src/test/java/com/yegor256/together/execution/JobTest.java
+++ b/src/test/java/com/yegor256/together/execution/JobTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Job}.
- *
  * @since 1.0
  */
 final class JobTest {

--- a/src/test/java/com/yegor256/together/execution/StartedTest.java
+++ b/src/test/java/com/yegor256/together/execution/StartedTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Started}.
- *
  * @since 1.0
  */
 @SuppressWarnings("PMD.UnnecessaryLocalRule")

--- a/src/test/java/com/yegor256/together/execution/StartedTest.java
+++ b/src/test/java/com/yegor256/together/execution/StartedTest.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.execution;
+
+import com.yegor256.TogetherFailure;
+import com.yegor256.together.policy.Deadline;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Started}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
+final class StartedTest {
+
+    @Test
+    void failsWhenTimedOut() {
+        final Started<Integer> started = new Started<>(
+            new java.util.concurrent.CountDownLatch(1),
+            new ExecutorCompletionService<>(Executors.newSingleThreadExecutor()),
+            new HashMap<>()
+        );
+        started.start();
+        final TogetherFailure failure = Assertions.assertThrows(
+            TogetherFailure.class,
+            () -> started.next(0, new Deadline(1L, TimeUnit.MILLISECONDS), 0),
+            "must fail on timeout"
+        );
+        MatcherAssert.assertThat(
+            "must mark timeout",
+            failure.causedByTimeout(),
+            Matchers.is(true)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/execution/package-info.java
+++ b/src/test/java/com/yegor256/together/execution/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests for execution objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.execution;

--- a/src/test/java/com/yegor256/together/execution/package-info.java
+++ b/src/test/java/com/yegor256/together/execution/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for execution objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.execution;

--- a/src/test/java/com/yegor256/together/failure/FailureContextTest.java
+++ b/src/test/java/com/yegor256/together/failure/FailureContextTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link FailureContext}.
- *
  * @since 1.0
  */
 final class FailureContextTest {

--- a/src/test/java/com/yegor256/together/failure/FailureContextTest.java
+++ b/src/test/java/com/yegor256/together/failure/FailureContextTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.failure;
+
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link FailureContext}.
+ *
+ * @since 1.0
+ */
+final class FailureContextTest {
+
+    @Test
+    void recognizesRoundAndThread() {
+        final FailureContext context = new FailureContext(2, 7, 15L);
+        MatcherAssert.assertThat(
+            "must recognize round",
+            context.happenedInRound(2) && context.happenedInThread(7),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsDifferentRoundAndThread() {
+        final FailureContext context = new FailureContext(2, 7, 15L);
+        MatcherAssert.assertThat(
+            "must reject different round and thread",
+            context.happenedInRound(3) || context.happenedInThread(8),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void comparesElapsedTime() {
+        MatcherAssert.assertThat(
+            "must compare elapsed time",
+            new FailureContext(2, 7, 15L).lastedAtLeast(
+                10L, TimeUnit.MILLISECONDS
+            ),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsLongerElapsedTime() {
+        MatcherAssert.assertThat(
+            "must reject larger duration",
+            new FailureContext(2, 7, 15L).lastedAtLeast(
+                16L, TimeUnit.MILLISECONDS
+            ),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void buildsMessageForTimeout() {
+        MatcherAssert.assertThat(
+            "must describe timeout",
+            new FailureContext(2, 7, 15L).messageFor(
+                new FailureKind(true, "boom")
+            ),
+            Matchers.containsString("timeout was exceeded")
+        );
+    }
+
+    @Test
+    void buildsMessageForRegularFailure() {
+        MatcherAssert.assertThat(
+            "must describe regular failure",
+            new FailureContext(2, 7, 15L).messageFor(
+                new FailureKind(false, "boom")
+            ),
+            Matchers.containsString(": boom")
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/failure/FailureKindTest.java
+++ b/src/test/java/com/yegor256/together/failure/FailureKindTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.failure;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link FailureKind}.
+ *
+ * @since 1.0
+ */
+final class FailureKindTest {
+
+    @Test
+    void recognizesTimeoutAndMessage() {
+        final FailureKind kind = new FailureKind(true, "boom");
+        MatcherAssert.assertThat(
+            "must keep timeout and message",
+            kind.causedByTimeout() && kind.hasMessage(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void returnsMessageText() {
+        MatcherAssert.assertThat(
+            "must return root message",
+            new FailureKind(false, "boom").messageText(),
+            Matchers.equalTo("boom")
+        );
+    }
+
+    @Test
+    void recognizesRegularFailureWithoutMessage() {
+        final FailureKind kind = new FailureKind(false, (String) null);
+        MatcherAssert.assertThat(
+            "must keep non-timeout empty state",
+            kind.causedByTimeout() || kind.hasMessage(),
+            Matchers.is(false)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/failure/FailureKindTest.java
+++ b/src/test/java/com/yegor256/together/failure/FailureKindTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link FailureKind}.
- *
  * @since 1.0
  */
 final class FailureKindTest {

--- a/src/test/java/com/yegor256/together/failure/package-info.java
+++ b/src/test/java/com/yegor256/together/failure/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Tests for failure objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.failure;

--- a/src/test/java/com/yegor256/together/failure/package-info.java
+++ b/src/test/java/com/yegor256/together/failure/package-info.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
 /**
  * Tests for failure objects.
  *

--- a/src/test/java/com/yegor256/together/failure/package-info.java
+++ b/src/test/java/com/yegor256/together/failure/package-info.java
@@ -4,7 +4,6 @@
  */
 /**
  * Tests for failure objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.failure;

--- a/src/test/java/com/yegor256/together/policy/DeadlineTest.java
+++ b/src/test/java/com/yegor256/together/policy/DeadlineTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Deadline}.
- *
  * @since 1.0
  */
 @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")

--- a/src/test/java/com/yegor256/together/policy/DeadlineTest.java
+++ b/src/test/java/com/yegor256/together/policy/DeadlineTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Deadline}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+final class DeadlineTest {
+
+    @Test
+    void keepsPositiveRemainingTimeout() {
+        final Deadline deadline = new Deadline(50L, TimeUnit.MILLISECONDS);
+        final long left = deadline.from(System.nanoTime());
+        MatcherAssert.assertThat(
+            "must keep timeout positive",
+            left > 0L,
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "must not increase timeout",
+            left <= 50L,
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "must keep time unit",
+            deadline.timeUnit(),
+            Matchers.equalTo(TimeUnit.MILLISECONDS)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/policy/ForeverTest.java
+++ b/src/test/java/com/yegor256/together/policy/ForeverTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Forever}.
- *
  * @since 1.0
  */
 final class ForeverTest {

--- a/src/test/java/com/yegor256/together/policy/ForeverTest.java
+++ b/src/test/java/com/yegor256/together/policy/ForeverTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.race.Scenario;
+import com.yegor256.together.race.Threads;
+import java.util.concurrent.ExecutorService;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Forever}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
+final class ForeverTest {
+
+    @Test
+    void waitsForNextExecutionWithoutTimeout() {
+        final Scenario<Integer> scenario =
+            new Scenario<>(new Threads(1), thread -> thread + 5);
+        try (ExecutorService service = scenario.newService()) {
+            final com.yegor256.together.execution.Started<Integer> started =
+                scenario.startedOn(service);
+            started.start();
+            MatcherAssert.assertThat(
+                "must return next execution",
+                scenario.newCompleted()
+                    .with(new Forever().waitFor(scenario.newCompleted(), 0, started))
+                    .resultsIn(0),
+                Matchers.contains(5)
+            );
+        }
+    }
+}

--- a/src/test/java/com/yegor256/together/policy/ForeverTest.java
+++ b/src/test/java/com/yegor256/together/policy/ForeverTest.java
@@ -16,14 +16,15 @@ import org.junit.jupiter.api.Test;
  *
  * @since 1.0
  */
-@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class ForeverTest {
 
     @Test
+    @SuppressWarnings("PMD.CloseResource")
     void waitsForNextExecutionWithoutTimeout() {
         final Scenario<Integer> scenario =
             new Scenario<>(new Threads(1), thread -> thread + 5);
-        try (ExecutorService service = scenario.newService()) {
+        final ExecutorService service = scenario.newService();
+        try {
             final com.yegor256.together.execution.Started<Integer> started =
                 scenario.startedOn(service);
             started.start();
@@ -34,6 +35,8 @@ final class ForeverTest {
                     .resultsIn(0),
                 Matchers.contains(5)
             );
+        } finally {
+            new com.yegor256.together.support.Shutdown(service).finish();
         }
     }
 }

--- a/src/test/java/com/yegor256/together/policy/LimitedTest.java
+++ b/src/test/java/com/yegor256/together/policy/LimitedTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Limited}.
- *
  * @since 1.0
  */
 @SuppressWarnings("PMD.UnnecessaryLocalRule")

--- a/src/test/java/com/yegor256/together/policy/LimitedTest.java
+++ b/src/test/java/com/yegor256/together/policy/LimitedTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 final class LimitedTest {
 
     @Test
+    @SuppressWarnings("PMD.CloseResource")
     void failsOnTimeout() {
         final Scenario<Integer> scenario = new Scenario<>(
             new Threads(1),
@@ -31,7 +32,8 @@ final class LimitedTest {
                 return thread;
             }
         );
-        try (ExecutorService service = scenario.newService()) {
+        final ExecutorService service = scenario.newService();
+        try {
             final com.yegor256.together.execution.Started<Integer> started =
                 scenario.startedOn(service);
             started.start();
@@ -47,6 +49,8 @@ final class LimitedTest {
                 failure.causedByTimeout(),
                 Matchers.is(true)
             );
+        } finally {
+            new com.yegor256.together.support.Shutdown(service).finish();
         }
     }
 

--- a/src/test/java/com/yegor256/together/policy/LimitedTest.java
+++ b/src/test/java/com/yegor256/together/policy/LimitedTest.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.TogetherFailure;
+import com.yegor256.together.race.Scenario;
+import com.yegor256.together.race.Threads;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Limited}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
+final class LimitedTest {
+
+    @Test
+    void failsOnTimeout() {
+        final Scenario<Integer> scenario = new Scenario<>(
+            new Threads(1),
+            thread -> {
+                Thread.sleep(100L);
+                return thread;
+            }
+        );
+        try (ExecutorService service = scenario.newService()) {
+            final com.yegor256.together.execution.Started<Integer> started =
+                scenario.startedOn(service);
+            started.start();
+            final TogetherFailure failure = Assertions.assertThrows(
+                TogetherFailure.class,
+                () -> new Limited(10L, TimeUnit.MILLISECONDS).waitFor(
+                    scenario.newCompleted(), 0, started
+                ),
+                "must fail on timeout"
+            );
+            MatcherAssert.assertThat(
+                "must mark timeout failures",
+                failure.causedByTimeout(),
+                Matchers.is(true)
+            );
+        }
+    }
+
+    @Test
+    void rejectsNonPositiveTimeout() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Limited(0L, TimeUnit.MILLISECONDS),
+            "must reject invalid timeout"
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/policy/StopFastTest.java
+++ b/src/test/java/com/yegor256/together/policy/StopFastTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link StopFast}.
- *
  * @since 1.0
  */
 final class StopFastTest {

--- a/src/test/java/com/yegor256/together/policy/StopFastTest.java
+++ b/src/test/java/com/yegor256/together/policy/StopFastTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.TogetherFailure;
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Execution;
+import com.yegor256.together.execution.Started;
+import com.yegor256.together.race.Threads;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link StopFast}.
+ *
+ * @since 1.0
+ */
+final class StopFastTest {
+
+    @Test
+    void throwsOnFirstFailure() {
+        Assertions.assertThrows(
+            TogetherFailure.class,
+            () -> new StopFast().reactTo(
+                0,
+                new Started<>(
+                    new java.util.concurrent.CountDownLatch(0),
+                    new ExecutorCompletionService<>(Executors.newSingleThreadExecutor()),
+                    new HashMap<>()
+                ),
+                new Completed<Integer>(new Threads(1)).with(
+                    new Execution<>(0, new IllegalStateException("boom"), 0L)
+                )
+            ),
+            "must throw on the first failure"
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/policy/WaitForAllTest.java
+++ b/src/test/java/com/yegor256/together/policy/WaitForAllTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.execution.Completed;
+import com.yegor256.together.execution.Execution;
+import com.yegor256.together.execution.Started;
+import com.yegor256.together.race.Threads;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link WaitForAll}.
+ *
+ * @since 1.0
+ */
+final class WaitForAllTest {
+
+    @Test
+    void leavesCompletedResultsUntouched() {
+        final Completed<Integer> completed = new Completed<Integer>(new Threads(1))
+            .with(new Execution<Integer>(0, 7, 0L));
+        new WaitForAll().reactTo(
+            0,
+            new Started<>(
+                new java.util.concurrent.CountDownLatch(0),
+                new ExecutorCompletionService<>(Executors.newSingleThreadExecutor()),
+                new HashMap<>()
+            ),
+            completed
+        );
+        MatcherAssert.assertThat(
+            "must keep collected results",
+            completed.resultsIn(0),
+            Matchers.contains(7)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/policy/WaitForAllTest.java
+++ b/src/test/java/com/yegor256/together/policy/WaitForAllTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link WaitForAll}.
- *
  * @since 1.0
  */
 final class WaitForAllTest {

--- a/src/test/java/com/yegor256/together/policy/WatchingTest.java
+++ b/src/test/java/com/yegor256/together/policy/WatchingTest.java
@@ -16,14 +16,15 @@ import org.junit.jupiter.api.Test;
  *
  * @since 1.0
  */
-@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class WatchingTest {
 
     @Test
+    @SuppressWarnings("PMD.CloseResource")
     void collectsResultsFromStartedExecution() {
         final Scenario<Integer> scenario =
             new Scenario<>(new Threads(2), thread -> thread);
-        try (ExecutorService service = scenario.newService()) {
+        final ExecutorService service = scenario.newService();
+        try {
             MatcherAssert.assertThat(
                 "must collect all results",
                 new Watching().collectFrom(
@@ -33,6 +34,8 @@ final class WatchingTest {
                 ),
                 Matchers.contains(0, 1)
             );
+        } finally {
+            new com.yegor256.together.support.Shutdown(service).finish();
         }
     }
 }

--- a/src/test/java/com/yegor256/together/policy/WatchingTest.java
+++ b/src/test/java/com/yegor256/together/policy/WatchingTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Watching}.
- *
  * @since 1.0
  */
 final class WatchingTest {

--- a/src/test/java/com/yegor256/together/policy/WatchingTest.java
+++ b/src/test/java/com/yegor256/together/policy/WatchingTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.policy;
+
+import com.yegor256.together.race.Scenario;
+import com.yegor256.together.race.Threads;
+import java.util.concurrent.ExecutorService;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Watching}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
+final class WatchingTest {
+
+    @Test
+    void collectsResultsFromStartedExecution() {
+        final Scenario<Integer> scenario =
+            new Scenario<>(new Threads(2), thread -> thread);
+        try (ExecutorService service = scenario.newService()) {
+            MatcherAssert.assertThat(
+                "must collect all results",
+                new Watching().collectFrom(
+                    0,
+                    scenario.newCompleted(),
+                    scenario.startedOn(service)
+                ),
+                Matchers.contains(0, 1)
+            );
+        }
+    }
+}

--- a/src/test/java/com/yegor256/together/policy/package-info.java
+++ b/src/test/java/com/yegor256/together/policy/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for policy objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.policy;

--- a/src/test/java/com/yegor256/together/policy/package-info.java
+++ b/src/test/java/com/yegor256/together/policy/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests for policy objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.policy;

--- a/src/test/java/com/yegor256/together/race/RaceTest.java
+++ b/src/test/java/com/yegor256/together/race/RaceTest.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Race}.
+ *
+ * @since 1.0
+ */
+final class RaceTest {
+
+    @Test
+    void runsConfiguredRace() {
+        MatcherAssert.assertThat(
+            "must execute all rounds",
+            new Race<>(
+                2,
+                thread -> thread
+            ).repeated(2).withTimeout(1L, TimeUnit.SECONDS).failFast().asList(),
+            Matchers.contains(0, 1, 0, 1)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/race/RaceTest.java
+++ b/src/test/java/com/yegor256/together/race/RaceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Race}.
- *
  * @since 1.0
  */
 final class RaceTest {

--- a/src/test/java/com/yegor256/together/race/RoundTest.java
+++ b/src/test/java/com/yegor256/together/race/RoundTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Round}.
- *
  * @since 1.0
  */
 final class RoundTest {

--- a/src/test/java/com/yegor256/together/race/RoundTest.java
+++ b/src/test/java/com/yegor256/together/race/RoundTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import java.util.concurrent.ExecutorService;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Round}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
+final class RoundTest {
+
+    @Test
+    void executesOneRound() {
+        final Threads threads = new Threads(2);
+        try (ExecutorService service = threads.newService()) {
+            MatcherAssert.assertThat(
+                "must execute one round only",
+                new Round<>(
+                    new Scenario<>(threads, thread -> thread),
+                    new com.yegor256.together.policy.Watching()
+                ).resultsOn(service, 0),
+                Matchers.contains(0, 1)
+            );
+        }
+    }
+}

--- a/src/test/java/com/yegor256/together/race/RoundTest.java
+++ b/src/test/java/com/yegor256/together/race/RoundTest.java
@@ -14,13 +14,14 @@ import org.junit.jupiter.api.Test;
  *
  * @since 1.0
  */
-@SuppressWarnings("PMD.UnnecessaryLocalRule")
 final class RoundTest {
 
     @Test
+    @SuppressWarnings("PMD.CloseResource")
     void executesOneRound() {
         final Threads threads = new Threads(2);
-        try (ExecutorService service = threads.newService()) {
+        final ExecutorService service = threads.newService();
+        try {
             MatcherAssert.assertThat(
                 "must execute one round only",
                 new Round<>(
@@ -29,6 +30,8 @@ final class RoundTest {
                 ).resultsOn(service, 0),
                 Matchers.contains(0, 1)
             );
+        } finally {
+            new com.yegor256.together.support.Shutdown(service).finish();
         }
     }
 }

--- a/src/test/java/com/yegor256/together/race/RoundsTest.java
+++ b/src/test/java/com/yegor256/together/race/RoundsTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Rounds}.
+ *
+ * @since 1.0
+ */
+final class RoundsTest {
+
+    @Test
+    void iteratesThroughAllRounds() {
+        MatcherAssert.assertThat(
+            "must expose all round numbers",
+            new Rounds(3),
+            Matchers.contains(0, 1, 2)
+        );
+    }
+
+    @Test
+    void rejectsNonPositiveCount() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Rounds(0),
+            "must reject invalid number of rounds"
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/race/RoundsTest.java
+++ b/src/test/java/com/yegor256/together/race/RoundsTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Rounds}.
- *
  * @since 1.0
  */
 final class RoundsTest {

--- a/src/test/java/com/yegor256/together/race/RulesTest.java
+++ b/src/test/java/com/yegor256/together/race/RulesTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Rules}.
- *
  * @since 1.0
  */
 final class RulesTest {
@@ -20,11 +19,10 @@ final class RulesTest {
     void appliesRulesToScenario() {
         MatcherAssert.assertThat(
             "must repeat scenario results",
-            new Rules().repeated(2).withTimeout(1L, TimeUnit.SECONDS).failFast()
-                .resultsOf(
-                    new Scenario<>(new Threads(2), thread -> thread),
-                    new Threads(2).newService()
-                ),
+            new Rules().repeated(2).withTimeout(1L, TimeUnit.SECONDS).failFast().resultsOf(
+                new Scenario<>(new Threads(2), thread -> thread),
+                new Threads(2).newService()
+            ),
             Matchers.contains(0, 1, 0, 1)
         );
     }

--- a/src/test/java/com/yegor256/together/race/RulesTest.java
+++ b/src/test/java/com/yegor256/together/race/RulesTest.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Rules}.
+ *
+ * @since 1.0
+ */
+final class RulesTest {
+
+    @Test
+    void appliesRulesToScenario() {
+        MatcherAssert.assertThat(
+            "must repeat scenario results",
+            new Rules().repeated(2).withTimeout(1L, TimeUnit.SECONDS).failFast()
+                .resultsOf(
+                    new Scenario<>(new Threads(2), thread -> thread),
+                    new Threads(2).newService()
+                ),
+            Matchers.contains(0, 1, 0, 1)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/race/ScenarioTest.java
+++ b/src/test/java/com/yegor256/together/race/ScenarioTest.java
@@ -16,12 +16,13 @@ import org.junit.jupiter.api.Test;
 final class ScenarioTest {
 
     @Test
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    @SuppressWarnings({"PMD.UnnecessaryLocalRule", "PMD.CloseResource"})
     void createsStartedAndCompletedObjects() {
         final Threads threads = new Threads(1);
         final Scenario<Integer> scenario =
             new Scenario<>(threads, thread -> thread + 1);
-        try (java.util.concurrent.ExecutorService service = scenario.newService()) {
+        final java.util.concurrent.ExecutorService service = scenario.newService();
+        try {
             final com.yegor256.together.execution.Started<Integer> started =
                 scenario.startedOn(service);
             started.start();
@@ -30,6 +31,8 @@ final class ScenarioTest {
                 scenario.newCompleted().with(started.next(0)).resultsIn(0),
                 Matchers.contains(1)
             );
+        } finally {
+            new com.yegor256.together.support.Shutdown(service).finish();
         }
     }
 }

--- a/src/test/java/com/yegor256/together/race/ScenarioTest.java
+++ b/src/test/java/com/yegor256/together/race/ScenarioTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Scenario}.
- *
  * @since 1.0
  */
 final class ScenarioTest {

--- a/src/test/java/com/yegor256/together/race/ScenarioTest.java
+++ b/src/test/java/com/yegor256/together/race/ScenarioTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Scenario}.
+ *
+ * @since 1.0
+ */
+final class ScenarioTest {
+
+    @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void createsStartedAndCompletedObjects() {
+        final Threads threads = new Threads(1);
+        final Scenario<Integer> scenario =
+            new Scenario<>(threads, thread -> thread + 1);
+        try (java.util.concurrent.ExecutorService service = scenario.newService()) {
+            final com.yegor256.together.execution.Started<Integer> started =
+                scenario.startedOn(service);
+            started.start();
+            MatcherAssert.assertThat(
+                "must execute submitted job",
+                scenario.newCompleted().with(started.next(0)).resultsIn(0),
+                Matchers.contains(1)
+            );
+        }
+    }
+}

--- a/src/test/java/com/yegor256/together/race/ThreadsTest.java
+++ b/src/test/java/com/yegor256/together/race/ThreadsTest.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.race;
+
+import com.yegor256.together.execution.Execution;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Threads}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+final class ThreadsTest {
+
+    @Test
+    void managesThreadLayout() {
+        final Threads threads = new Threads(3);
+        final Map<Integer, Execution<Integer>> done = new HashMap<>();
+        done.put(0, new Execution<>(0, 0, 0L));
+        done.put(2, new Execution<>(2, 2, 0L));
+        MatcherAssert.assertThat(
+            "must find missing thread",
+            threads.firstAbsentFrom(new HashMap<Integer, Execution<?>>(done)),
+            Matchers.equalTo(1)
+        );
+        final java.util.List<Integer> results = new java.util.ArrayList<>(3);
+        done.put(1, new Execution<>(1, 1, 0L));
+        threads.appendTo(done, 0, results);
+        MatcherAssert.assertThat(
+            "must append results in order",
+            results,
+            Matchers.contains(0, 1, 2)
+        );
+    }
+
+    @Test
+    void iteratesAllThreadsAndRecognizesCompleteState() {
+        final Threads threads = new Threads(3);
+        final Map<Integer, Execution<?>> done = new HashMap<>();
+        done.put(0, new Execution<>(0, 0, 0L));
+        done.put(1, new Execution<>(1, 1, 0L));
+        done.put(2, new Execution<>(2, 2, 0L));
+        MatcherAssert.assertThat(
+            "must keep all thread numbers",
+            new java.util.ArrayList<Integer>(
+                Arrays.asList(
+                    threads.inRandomOrder().iterator().next(),
+                    threads.inRandomOrder().iterator().next(),
+                    threads.inRandomOrder().iterator().next()
+                )
+            ).size(),
+            Matchers.equalTo(3)
+        );
+        MatcherAssert.assertThat(
+            "must recognize complete state",
+            threads.misses(done),
+            Matchers.is(false)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/race/ThreadsTest.java
+++ b/src/test/java/com/yegor256/together/race/ThreadsTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Threads}.
- *
  * @since 1.0
  */
 @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")

--- a/src/test/java/com/yegor256/together/race/package-info.java
+++ b/src/test/java/com/yegor256/together/race/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for race objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.race;

--- a/src/test/java/com/yegor256/together/race/package-info.java
+++ b/src/test/java/com/yegor256/together/race/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests for race objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.race;

--- a/src/test/java/com/yegor256/together/support/IterTest.java
+++ b/src/test/java/com/yegor256/together/support/IterTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Iter}.
- *
  * @since 1.0
  */
 @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")

--- a/src/test/java/com/yegor256/together/support/IterTest.java
+++ b/src/test/java/com/yegor256/together/support/IterTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.support;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Iter}.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+final class IterTest {
+
+    @Test
+    void iteratesAndPrintsItems() {
+        final Iter<Integer> iter = new Iter<>(new LinkedList<>(Arrays.asList(1, 2)));
+        MatcherAssert.assertThat(
+            "must print all items",
+            iter.toString(),
+            Matchers.equalTo("[1, 2]")
+        );
+        MatcherAssert.assertThat(
+            "must iterate through all items",
+            new LinkedList<>(Arrays.asList(iter.next(), iter.next())),
+            Matchers.contains(1, 2)
+        );
+        MatcherAssert.assertThat(
+            "must finish iteration",
+            iter.hasNext(),
+            Matchers.is(false)
+        );
+    }
+}

--- a/src/test/java/com/yegor256/together/support/ShutdownTest.java
+++ b/src/test/java/com/yegor256/together/support/ShutdownTest.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256.together.support;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Shutdown}.
+ *
+ * @since 1.0
+ */
+final class ShutdownTest {
+
+    @Test
+    void shutsExecutorDown() {
+        try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+            new Shutdown(service).finish();
+            MatcherAssert.assertThat(
+                "must shutdown executor",
+                service.isShutdown(),
+                Matchers.is(true)
+            );
+        }
+    }
+
+    @Test
+    void failsOnInterruptedShutdown() {
+        try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+            service.submit(
+                () -> {
+                    Thread.sleep(1000L);
+                    return 1;
+                }
+            );
+            Thread.currentThread().interrupt();
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new Shutdown(service).finish(),
+                "must convert interrupted shutdown"
+            );
+            MatcherAssert.assertThat(
+                "must preserve interrupted flag",
+                Thread.currentThread().isInterrupted(),
+                Matchers.is(true)
+            );
+            Thread.interrupted();
+        }
+    }
+}

--- a/src/test/java/com/yegor256/together/support/ShutdownTest.java
+++ b/src/test/java/com/yegor256/together/support/ShutdownTest.java
@@ -19,20 +19,26 @@ import org.junit.jupiter.api.Test;
 final class ShutdownTest {
 
     @Test
+    @SuppressWarnings("PMD.CloseResource")
     void shutsExecutorDown() {
-        try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+        final ExecutorService service = Executors.newSingleThreadExecutor();
+        try {
             new Shutdown(service).finish();
             MatcherAssert.assertThat(
                 "must shutdown executor",
                 service.isShutdown(),
                 Matchers.is(true)
             );
+        } finally {
+            service.shutdownNow();
         }
     }
 
     @Test
+    @SuppressWarnings("PMD.CloseResource")
     void failsOnInterruptedShutdown() {
-        try (ExecutorService service = Executors.newSingleThreadExecutor()) {
+        final ExecutorService service = Executors.newSingleThreadExecutor();
+        try {
             service.submit(
                 () -> {
                     Thread.sleep(1000L);
@@ -51,6 +57,8 @@ final class ShutdownTest {
                 Matchers.is(true)
             );
             Thread.interrupted();
+        } finally {
+            service.shutdownNow();
         }
     }
 }

--- a/src/test/java/com/yegor256/together/support/ShutdownTest.java
+++ b/src/test/java/com/yegor256/together/support/ShutdownTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Shutdown}.
- *
  * @since 1.0
  */
 final class ShutdownTest {

--- a/src/test/java/com/yegor256/together/support/package-info.java
+++ b/src/test/java/com/yegor256/together/support/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for support objects.
+ *
+ * @since 1.0
+ */
+package com.yegor256.together.support;

--- a/src/test/java/com/yegor256/together/support/package-info.java
+++ b/src/test/java/com/yegor256/together/support/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests for support objects.
- *
  * @since 1.0
  */
 package com.yegor256.together.support;


### PR DESCRIPTION
## What

This PR extends `Together` with three new capabilities while keeping the existing public entry points backward compatible:

- add `repeated(int)` to run the same concurrency scenario multiple times
- add `withTimeout(long, TimeUnit)` to bound each round and prevent hanging tests
- add `failFast()` to stop waiting for the rest of the threads after the first failure

It also introduces `TogetherFailure` for richer diagnostics and reorganizes the internal implementation into smaller domain-focused packages (`race`, `policy`, `execution`, `failure`, `support`).

## Why

Concurrency bugs are often statistical: a race condition may not reproduce on the first run, but appear on the 20th or 200th run. Repeated execution makes the library much more useful for real thread-safety testing.

Timeout support makes tests safer in CI by preventing deadlocks or stuck threads from hanging the build forever.

Fail-fast behavior shortens feedback time when one thread has already demonstrated that the scenario failed.

Richer failure diagnostics make debugging easier by showing whether the failure was caused by a timeout and by preserving round/thread context.

## Compatibility

This change keeps the existing usage style intact:

- `new Together<>(action)`
- `new Together<>(threads, action)`

The new failure type still extends `IllegalArgumentException`, so existing catch blocks remain compatible.

## Implementation Notes

- the public facade remains `Together`
- the new behavior is implemented through smaller OOP-oriented internal objects
- tests were expanded and split so the new classes and behaviors are covered individually
- README examples were updated to document the new API