### PR TITLE
Upgrade dependencies and plugins to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.72.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>com.yegor256</groupId>
   <artifactId>together</artifactId>
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.57.0</version>
+      <version>0.61.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -94,7 +94,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.9.8.2</version>
+        <version>4.9.8.3</version>
         <executions>
           <execution>
             <goals>
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.22.1</version>
+        <version>1.23.1</version>
         <executions>
           <execution>
             <goals>
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.0</version>
+            <version>0.27.5</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>


### PR DESCRIPTION
@yegor256 hi, this PR upgrades all direct dependencies and plugins in `pom.xml` to their latest stable versions:

| Item | From | To |
| --- | --- | --- |
| `com.jcabi:parent` (parent) | 0.72.0 | 0.73.1 |
| `org.cactoos:cactoos` (test dep) | 0.57.0 | 0.61.0 |
| `com.github.spotbugs:spotbugs-maven-plugin` | 4.9.8.2 | 4.9.8.3 |
| `org.pitest:pitest-maven` | 1.22.1 | 1.23.1 |
| `com.qulice:qulice-maven-plugin` | 0.27.0 | 0.27.5 |

All three matrix `mvn` jobs (ubuntu-24.04, macos-15, windows-2022 on Java 21) and every linter pass on this branch. Locally I ran `mvn -Pqulice -Psite clean install site` to validate qulice + the site goal.

The first CI attempt had `TogetherTest.overlapsThreads` fail on the ubuntu runner — that test relies on a 1ms sleep to make two threads overlap and is sensitive to runner load (master has shown the same flake). A re-run passed cleanly on all three OSes, so no source change was needed for that. After the fixes here, every check is green and the PR is ready to merge whenever it suits you. Thanks!